### PR TITLE
Fixes/update person

### DIFF
--- a/src/lib/server/hooks/website/utils/update_person.ts
+++ b/src/lib/server/hooks/website/utils/update_person.ts
@@ -75,7 +75,7 @@ export default async function ({
 				: { petitionId: type.petition_id, petitionName: type.petition_name };
 		const created = await createPerson({
 			instance_id: instanceId,
-			body: { ...personInfo, country: personInfo.country || DEFAULT_COUNTRY, full_name },
+			body: { ...personInfo, country: personInfo.country || country, full_name },
 			admin_id: adminId,
 			queue,
 			method: type.method,

--- a/src/lib/server/hooks/website/utils/update_person.ts
+++ b/src/lib/server/hooks/website/utils/update_person.ts
@@ -6,7 +6,7 @@ import {
 	getIdsFromEmailPhoneNumber,
 	create as createPerson
 } from '$lib/server/api/people/people';
-import { parse, type Country } from '$lib/schema/valibot';
+import { DEFAULT_COUNTRY, parse, type Country } from '$lib/schema/valibot';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
 
 type SignupType =
@@ -69,12 +69,18 @@ export default async function ({
 		const full_name = personInfo.full_name
 			? personInfo.full_name.trim()
 			: `${personInfo.given_name} ${personInfo.family_name}`.trim(); //TODO: Make name construction dependent on locale
+		const createOptions =
+			type.method === 'event_registration'
+				? { eventId: type.event_id, eventName: type.event_name }
+				: { petitionId: type.petition_id, petitionName: type.petition_name };
 		const created = await createPerson({
 			instance_id: instanceId,
-			body: { ...personInfo, full_name },
+			body: { ...personInfo, country: personInfo.country || DEFAULT_COUNTRY, full_name },
 			admin_id: adminId,
 			queue,
-			t
+			method: type.method,
+			t,
+			options: createOptions
 		});
 		await queueInteraction({
 			personId: created.id,


### PR DESCRIPTION
Previously new people created via signing up for an event or signing a petition were being treated as manually created/added people in terms of "interactions" that appear on their profile. This is a quick update to make sure they are properly listed as event signups or petition signatures with the event and petition properly recorded. 