### PR TITLE
Login redirect

### DIFF
--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -93,9 +93,13 @@ const belcodaHandler: Handle = async ({ event, resolve }) => {
 	}
 
 	if (!authenticated) {
+		// Get the url that the user is trying to visit for redirection after login
+		const url = event.url.pathname + event.url.search;
 		return new Response(null, {
 			status: 302,
-			headers: { location: '/login' }
+			headers: {
+				location: '/login' + (url === '/login' || url === '/' ? '' : '?continue=' + url)
+			}
 		});
 	}
 

--- a/src/routes/(utility)/auth/google/+server.ts
+++ b/src/routes/(utility)/auth/google/+server.ts
@@ -10,6 +10,7 @@ import { BelcodaError } from '$lib/server';
 export const POST = async function (event) {
 	try {
 		const tokenCookie = event.cookies.get('g_csrf_token');
+		const continueUrl = event.url.searchParams.get('continue');
 		const body = await event.request.formData();
 		const tokenBody = body.get('g_csrf_token');
 		const credential = body.get('credential');
@@ -24,7 +25,7 @@ export const POST = async function (event) {
 			body: parsedSignInDetails
 		});
 		event.cookies.set(COOKIE_SESSION_NAME, session, { path: '/' });
-		return redirect(302, '/');
+		return redirect(302, continueUrl ? continueUrl : '/');
 	} catch (err) {
 		if (err instanceof Error) {
 			throw new BelcodaError(

--- a/src/routes/(utility)/login/+page.svelte
+++ b/src/routes/(utility)/login/+page.svelte
@@ -1,6 +1,13 @@
 <script lang="ts">
 	import { PUBLIC_HOST, PUBLIC_GOOGLE_AUTH_CLIENT_ID } from '$env/static/public';
 	import H2 from '$lib/comps/typography/H2.svelte';
+	import { page } from '$app/stores';
+
+    // Update the login_uri to include the continue parameter if it exists
+    $: continueUrl = $page.url.searchParams.get('continue');
+    $: loginUri = continueUrl 
+        ? `${PUBLIC_HOST}/auth/google?continue=${continueUrl}` 
+        : `${PUBLIC_HOST}/auth/google`;
 </script>
 
 <svelte:head>
@@ -24,7 +31,7 @@
 					data-client_id={PUBLIC_GOOGLE_AUTH_CLIENT_ID}
 					data-context="signin"
 					data-ux_mode="popup"
-					data-login_uri={`${PUBLIC_HOST}/auth/google`}
+					data-login_uri={loginUri}
 					data-auto_prompt="false"
 				></div>
 


### PR DESCRIPTION
When a user that isn't authenticated tries navigating to a protected route, we redirect them to the login page and after they authenticate, they are redirected to the route they tried accessing.

This PR uses URL params to store the redirect URL for the user.