### PR TITLE
Fixes/user filtering

### DIFF
--- a/src/lib/comps/widgets/events/EventDropdown.svelte
+++ b/src/lib/comps/widgets/events/EventDropdown.svelte
@@ -7,7 +7,7 @@
 	type Props = {
 		item?: List['items'][number];
 		items?: List['items'];
-		value?: number;
+		value?: number | null;
 		onselect: (item: List['items'][number]) => void;
 		children?: Snippet;
 	};
@@ -46,7 +46,7 @@
 		item = items[selected];
 	}
 
-	let searchString: string | undefined = $state();
+	let searchString: string = $state('');
 
 	async function search() {
 		loading = true;

--- a/src/lib/comps/widgets/lists/ListDropdown.svelte
+++ b/src/lib/comps/widgets/lists/ListDropdown.svelte
@@ -7,7 +7,7 @@
 	type Props = {
 		list?: List['items'][number];
 		lists?: List['items'];
-		value?: number;
+		value?: number | null;
 		label?: string;
 		onSelectList?: (list: List['items'][number]) => void;
 		children?: Snippet;

--- a/src/lib/comps/widgets/tags/dropdown/TagsDropdown.svelte
+++ b/src/lib/comps/widgets/tags/dropdown/TagsDropdown.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { type List } from '$lib/schema/core/tags';
-	import { debounce } from '$lib/utils';
+	import { cn, debounce } from '$lib/utils';
 	import type { Snippet } from 'svelte';
 	type Props = {
 		item?: List['items'][number];
 		items?: List['items'];
-		value?: number;
+		value?: number | null;
 		onselect: (item: List['items'][number]) => void;
 		children?: Snippet;
 	};
@@ -24,7 +24,7 @@
 
 	import * as Command from '$lib/comps/ui/command';
 	import * as Popover from '$lib/comps/ui/popover';
-	import Button from '$lib/comps/ui/button/button.svelte';
+	import { buttonVariants } from '$lib/comps/ui/button/button.svelte';
 	import Plus from 'lucide-svelte/icons/plus';
 
 	import { onMount } from 'svelte';
@@ -45,7 +45,7 @@
 		item = items[selected];
 	}
 
-	let searchString: string | undefined = $state();
+	let searchString: string = $state('');
 
 	async function search() {
 		loading = true;
@@ -58,23 +58,21 @@
 	{@render popover()}
 </div>
 {#snippet popover()}
-	<Popover.Root bind:open let:ids>
-		<Popover.Trigger asChild let:builder>
-			<Button
-				size="sm"
-				builders={[builder]}
-				variant="outline"
-				class="justify-start gap-x-1 rounded-lg px-2 py-3"
-			>
-				{#if item}
-					{item.name}
-				{:else if children}
-					{@render children()}
-				{:else}
-					<Plus size={14} />
-					<div class="text-sm">{$page.data.t.forms.buttons.search()}</div>
-				{/if}
-			</Button>
+	<Popover.Root bind:open>
+		<Popover.Trigger
+			class={cn(
+				buttonVariants({ size: 'sm', variant: 'outline' }),
+				'justify-start gap-x-1 rounded-lg px-2 py-3'
+			)}
+		>
+			{#if item}
+				{item.name}
+			{:else if children}
+				{@render children()}
+			{:else}
+				<Plus size={14} />
+				<div class="text-sm">{$page.data.t.forms.buttons.search()}</div>
+			{/if}
 		</Popover.Trigger>
 		<Popover.Content class="p-0" align="start" side="right">
 			<Command.Root>
@@ -91,10 +89,8 @@
 						{#each items as object, i}
 							<Command.Item
 								value={`${object.id}:::${object.name}`}
-								onSelect={(v) => {
-									const id = v.split(':::')[0];
-									handleAdd(Number(id));
-									open = false;
+								onSelect={() => {
+									handleAdd(object.id);
 								}}
 							>
 								{object.name}

--- a/src/lib/schema/people/filters/defaults.ts
+++ b/src/lib/schema/people/filters/defaults.ts
@@ -1,0 +1,186 @@
+/**
+ * User filter defaults
+ *
+ * @author dmsynge
+ * @date 2024-12-16
+ *
+ * When a user switches between different filter types for filtering a list of people and building a complex advanced search, we need to provide default values for each filter type.
+ * Moreover, we need to do so in a type-safe way. This file contains the default values for each filter type.
+ */
+
+import { filterTypes } from '$lib/schema/people/filters/filters';
+import { v, id } from '$lib/schema/valibot';
+
+export const fullName = v.object({
+	...filterTypes.full_name.entries,
+	name: v.string()
+});
+export type FullName = v.InferInput<typeof fullName>;
+export const defaultFullName: FullName = {
+	type: 'full_name',
+	name: '',
+	partial: true
+};
+
+export const email = v.object({
+	...filterTypes.email.entries,
+	email: v.string()
+});
+export type Email = v.InferInput<typeof email>;
+export const defaultEmail: Email = {
+	type: 'email',
+	email: '',
+	partial: true,
+	mustBeSubscribed: false
+};
+
+export const postcode = v.object({
+	...filterTypes.postcode.entries,
+	postcode: v.string()
+});
+export type Postcode = v.InferInput<typeof postcode>;
+export const defaultPostcode: Postcode = {
+	type: 'postcode',
+	postcode: '',
+	partial: true
+};
+
+export const locality = v.object({
+	...filterTypes.locality.entries,
+	locality: v.string()
+});
+export type Locality = v.InferInput<typeof locality>;
+export const defaultLocality: Locality = {
+	type: 'locality',
+	locality: '',
+	partial: true
+};
+
+export const state = v.object({
+	...filterTypes.state.entries,
+	state: v.string()
+});
+export type State = v.InferInput<typeof state>;
+export const defaultState: State = {
+	type: 'state',
+	state: '',
+	partial: true
+};
+
+export const address = v.object({
+	...filterTypes.address.entries,
+	address: v.string()
+});
+export type Address = v.InferInput<typeof address>;
+export const defaultAddress: Address = {
+	type: 'address',
+	address: ''
+};
+
+export const phoneNumber = v.object({
+	...filterTypes.phone_number.entries,
+	phone_number: v.string()
+});
+export type PhoneNumber = v.InferInput<typeof phoneNumber>;
+export const defaultPhoneNumber: PhoneNumber = {
+	type: 'phone_number',
+	phone_number: '',
+	partial: true,
+	mustBeSubscribed: false,
+	mustBeWhatsapp: false
+};
+
+export const inList = v.object({
+	...filterTypes.in_list.entries,
+	list_id: v.nullable(id)
+});
+export type InList = v.InferInput<typeof inList>;
+export const defaultInList: InList = {
+	type: 'in_list',
+	list_id: null
+};
+
+const notInList = v.object({
+	...filterTypes.not_in_list.entries,
+	list_id: v.nullable(id)
+});
+export type NotInList = v.InferInput<typeof notInList>;
+export const defaultNotInList: NotInList = {
+	type: 'not_in_list',
+	list_id: null
+};
+
+export const hasTag = v.object({
+	...filterTypes.has_tag.entries,
+	tag_id: v.nullable(id)
+});
+export type HasTag = v.InferInput<typeof hasTag>;
+export const defaultHasTag: HasTag = {
+	type: 'has_tag',
+	tag_id: null
+};
+
+export const notHasTag = v.object({
+	...filterTypes.not_has_tag.entries,
+	tag_id: v.nullable(id)
+});
+export type NotHasTag = v.InferInput<typeof notHasTag>;
+export const defaultNotHasTag: NotHasTag = {
+	type: 'not_has_tag',
+	tag_id: null
+};
+
+export const registeredEvent = v.object({
+	...filterTypes.registered_event.entries,
+	event_id: v.nullable(id)
+});
+export type RegisteredEvent = v.InferInput<typeof registeredEvent>;
+export const defaultRegisteredEvent: RegisteredEvent = {
+	type: 'registered_event',
+	event_id: null,
+	status: 'any'
+};
+
+export const notRegisteredEvent = v.object({
+	...filterTypes.not_registered_event.entries,
+	event_id: v.nullable(id)
+});
+export type NotRegisteredEvent = v.InferInput<typeof notRegisteredEvent>;
+export const defaultNotRegisteredEvent: NotRegisteredEvent = {
+	type: 'not_registered_event',
+	event_id: null,
+	status: 'any'
+};
+
+export const defaultFilterTypes = v.variant('type', [
+	fullName,
+	email,
+	postcode,
+	locality,
+	state,
+	address,
+	phoneNumber,
+	inList,
+	notInList,
+	hasTag,
+	notHasTag,
+	registeredEvent,
+	notRegisteredEvent
+]);
+export type DefaultFilterTypes = v.InferInput<typeof defaultFilterTypes>;
+
+export const defaults = {
+	defaultAddress,
+	defaultEmail,
+	defaultFullName,
+	defaultHasTag,
+	defaultInList,
+	defaultLocality,
+	defaultNotHasTag,
+	defaultNotInList,
+	defaultNotRegisteredEvent,
+	defaultPhoneNumber,
+	defaultPostcode,
+	defaultRegisteredEvent,
+	defaultState
+};

--- a/src/lib/schema/people/filters/filters.ts
+++ b/src/lib/schema/people/filters/filters.ts
@@ -1,6 +1,23 @@
 import { v, id, mediumStringNotEmpty, shortStringNotEmpty } from '$lib/schema/valibot';
 import { attendeeStatus } from '$lib/schema/events/attendees';
 
+export const filterTypesOptions = v.picklist([
+	'email',
+	'full_name',
+	'postcode',
+	'locality',
+	'state',
+	'address',
+	'phone_number',
+	'in_list',
+	'not_in_list',
+	'has_tag',
+	'not_has_tag',
+	'registered_event',
+	'not_registered_event'
+]);
+export type FilterTypesOptions = v.InferOutput<typeof filterTypesOptions>;
+
 export const filterTypes = {
 	email: v.object({
 		type: v.literal('email'),
@@ -98,24 +115,6 @@ export const filterType = v.variant('type', [
 	filterTypes.not_registered_event
 ]);
 export type FilterType = v.InferOutput<typeof filterType>;
-export const DEFAULT_FILTER_TYPE: FilterType = {
-	type: 'full_name',
-	name: '',
-	partial: true
-};
-export const DEFAULT_EMAIL_FILTER_TYPE: FilterType = {
-	type: 'email',
-	email: '',
-	partial: true,
-	mustBeSubscribed: false
-};
-export const DEFAULT_PHONE_NUMBER_FILTER_TYPE: FilterType = {
-	type: 'phone_number',
-	phone_number: '',
-	partial: true,
-	mustBeSubscribed: false,
-	mustBeWhatsapp: false
-};
 
 export type FilterGroup = {
 	type: 'group';
@@ -134,7 +133,13 @@ export const filterGroup: v.GenericSchema<FilterGroup> = v.object({
 export const DEFAULT_FILTER_GROUP: FilterGroup = {
 	type: 'group',
 	groups: [],
-	filters: [DEFAULT_FILTER_TYPE],
+	filters: [
+		{
+			type: 'full_name',
+			name: '',
+			partial: true
+		}
+	],
 	logic: 'AND'
 };
 

--- a/src/lib/server/api/people/filters/advanced/has_tag.ts
+++ b/src/lib/server/api/people/filters/advanced/has_tag.ts
@@ -1,7 +1,7 @@
 import { format } from 'node-pg-format';
 export function filter({ instanceId, tagId }: { instanceId: number; tagId: number }) {
 	const query = format(
-		`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from people.taggings where tag_id = %L)`,
+		`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from people.taggings where tag_id = %L))`,
 		instanceId,
 		tagId
 	);

--- a/src/lib/server/api/people/filters/advanced/in_list.ts
+++ b/src/lib/server/api/people/filters/advanced/in_list.ts
@@ -1,7 +1,7 @@
 import { format } from 'node-pg-format';
 export function filter({ instanceId, listId }: { instanceId: number; listId: number }) {
 	const query = format(
-		`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from people.list_people where list_id = %L)`,
+		`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from people.list_people where list_id = %L))`,
 		instanceId,
 		listId
 	);

--- a/src/lib/server/api/people/filters/advanced/not_has_tag.ts
+++ b/src/lib/server/api/people/filters/advanced/not_has_tag.ts
@@ -1,7 +1,7 @@
 import { format } from 'node-pg-format';
 export function filter({ instanceId, tagId }: { instanceId: number; tagId: number }) {
 	const query = format(
-		`(SELECT id FROM people.people WHERE instance_id = %L AND id NOT IN (select person_id from people.taggings where tag_id = %L)`,
+		`(SELECT id FROM people.people WHERE instance_id = %L AND id NOT IN (select person_id from people.taggings where tag_id = %L))`,
 		instanceId,
 		tagId
 	);

--- a/src/lib/server/api/people/filters/advanced/not_in_list.ts
+++ b/src/lib/server/api/people/filters/advanced/not_in_list.ts
@@ -1,7 +1,7 @@
 import { format } from 'node-pg-format';
 export function filter({ instanceId, listId }: { instanceId: number; listId: number }) {
 	const query = format(
-		`(SELECT id FROM people.people WHERE instance_id = %L AND id NOT IN (select person_id from people.list_people where list_id = %L)`,
+		`(SELECT id FROM people.people WHERE instance_id = %L AND id NOT IN (select person_id from people.list_people where list_id = %L))`,
 		instanceId,
 		listId
 	);

--- a/src/lib/server/api/people/filters/advanced/registered_event.ts
+++ b/src/lib/server/api/people/filters/advanced/registered_event.ts
@@ -12,14 +12,14 @@ export function filter({
 }) {
 	if (status === 'any') {
 		const query = format(
-			`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from events.attendees where event_id = %L)`,
+			`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from events.attendees where event_id = %L))`,
 			instanceId,
 			eventId
 		);
 		return query;
 	} else {
 		const query = format(
-			`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from events.attendees where event_id = %L AND status = %L)`,
+			`(SELECT id FROM people.people WHERE instance_id = %L AND id IN (select person_id from events.attendees where event_id = %L AND status = %L))`,
 			instanceId,
 			eventId,
 			status

--- a/src/routes/(app)/people/filter/FilterGroupWidget.svelte
+++ b/src/routes/(app)/people/filter/FilterGroupWidget.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-	import { type FilterGroup, DEFAULT_FILTER_TYPE } from '$lib/schema/people/filters/filters';
+	import { type FilterGroup } from '$lib/schema/people/filters/filters';
+	import { defaultFullName } from '$lib/schema/people/filters/defaults';
 	import FilterGroupWidet from './FilterGroupWidget.svelte';
 	import { page } from '$app/stores';
 	let {
@@ -63,7 +64,7 @@
 			>{$page.data.t.forms.buttons.filters.add_group()}</Button
 		> -->
 		<!-- TODO: There's a strange bug here with recursive state triggering multiple group creation -->
-		<Button onclick={() => filter.filters.push(structuredClone(DEFAULT_FILTER_TYPE))}
+		<Button onclick={() => filter.filters.push(structuredClone(defaultFullName))}
 			>{$page.data.t.forms.buttons.filters.add_filter()}</Button
 		>
 	</div>

--- a/src/routes/(app)/people/filter/types/Address.svelte
+++ b/src/routes/(app)/people/filter/types/Address.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { type FilterTypeAddress } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeAddress } = $props();
+	import { type Address, defaultAddress } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultAddress) }: { item: Address } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 </script>
 

--- a/src/routes/(app)/people/filter/types/Email.svelte
+++ b/src/routes/(app)/people/filter/types/Email.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import {
-		type FilterTypeEmail,
-		DEFAULT_EMAIL_FILTER_TYPE
-	} from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeEmail } = $props();
-	item = { ...DEFAULT_EMAIL_FILTER_TYPE, ...item }; // to ensure none of the values are undefined
+	import { type Email, defaultEmail } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultEmail) }: { item: Email } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/FullName.svelte
+++ b/src/routes/(app)/people/filter/types/FullName.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { type FilterTypeFullName, DEFAULT_FILTER_TYPE } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeFullName } = $props();
-	item = { ...DEFAULT_FILTER_TYPE, ...item }; // to ensure none of the values are undefined
+	import { type FullName, defaultFullName } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultFullName) }: { item: FullName } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/HasTag.svelte
+++ b/src/routes/(app)/people/filter/types/HasTag.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { type FilterTypeHasTag } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeHasTag } = $props();
+	import { type HasTag, defaultHasTag } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultHasTag) }: { item: HasTag } = $props();
 	import TagsDropdown from '$lib/comps/widgets/tags/dropdown/TagsDropdown.svelte';
 </script>
 

--- a/src/routes/(app)/people/filter/types/InList.svelte
+++ b/src/routes/(app)/people/filter/types/InList.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { type FilterTypeInList } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeInList } = $props();
+	import { type InList, defaultInList } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultInList) }: { item: InList } = $props();
 	import ListDropdown from '$lib/comps/widgets/lists/ListDropdown.svelte';
 </script>
 

--- a/src/routes/(app)/people/filter/types/Locality.svelte
+++ b/src/routes/(app)/people/filter/types/Locality.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { type FilterTypeLocality } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeLocality } = $props();
+	import { type Locality, defaultLocality } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultLocality) }: { item: Locality } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/NotHasTag.svelte
+++ b/src/routes/(app)/people/filter/types/NotHasTag.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { type FilterTypeNotHasTag } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeNotHasTag } = $props();
+	import { type NotHasTag, defaultNotHasTag } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultNotHasTag) }: { item: NotHasTag } = $props();
 	import TagsDropdown from '$lib/comps/widgets/tags/dropdown/TagsDropdown.svelte';
 </script>
 

--- a/src/routes/(app)/people/filter/types/NotInList.svelte
+++ b/src/routes/(app)/people/filter/types/NotInList.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
-	import { page } from '$app/stores';
-	import { type FilterTypeNotInList } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeNotInList } = $props();
+	import { type NotInList, defaultNotInList } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultNotInList) }: { item: NotInList } = $props();
 	import ListDropdown from '$lib/comps/widgets/lists/ListDropdown.svelte';
 </script>
 

--- a/src/routes/(app)/people/filter/types/NotRegisteredEvent.svelte
+++ b/src/routes/(app)/people/filter/types/NotRegisteredEvent.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import { type FilterTypeNotRegisteredEvent } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeNotRegisteredEvent } = $props();
+	import {
+		type NotRegisteredEvent,
+		defaultNotRegisteredEvent
+	} from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultNotRegisteredEvent) }: { item: NotRegisteredEvent } = $props();
 	import EventDropdown from '$lib/comps/widgets/events/EventDropdown.svelte';
 	import * as Select from '$lib/comps/ui/select';
 
-	const statuses: { value: FilterTypeNotRegisteredEvent['status']; label: string }[] = [
+	const statuses: { value: NotRegisteredEvent['status']; label: string }[] = [
 		{ value: 'any', label: 'Any' },
 		{ value: 'registered', label: 'Registered' },
 		{ value: 'attended', label: 'Attended' },
@@ -22,7 +25,7 @@
 		value={statuses[0].value}
 		onValueChange={(val) => {
 			if (!val) return;
-			item.status = val as FilterTypeNotRegisteredEvent['status'];
+			item.status = val as NotRegisteredEvent['status'];
 		}}
 	>
 		<Select.Trigger class="w-[180px]">

--- a/src/routes/(app)/people/filter/types/PhoneNumber.svelte
+++ b/src/routes/(app)/people/filter/types/PhoneNumber.svelte
@@ -1,11 +1,7 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import {
-		type FilterTypePhoneNumber,
-		DEFAULT_PHONE_NUMBER_FILTER_TYPE
-	} from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypePhoneNumber } = $props();
-	item = { ...DEFAULT_PHONE_NUMBER_FILTER_TYPE, ...item }; // to ensure none of the values are undefined
+	import { type PhoneNumber, defaultPhoneNumber } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultPhoneNumber) }: { item: PhoneNumber } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/Postcode.svelte
+++ b/src/routes/(app)/people/filter/types/Postcode.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { type FilterTypePostcode } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypePostcode } = $props();
+
+	import { type Postcode, defaultPostcode } from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultPostcode) }: { item: Postcode } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/RegisteredEvent.svelte
+++ b/src/routes/(app)/people/filter/types/RegisteredEvent.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
-	import { type FilterTypeRegisteredEvent } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeRegisteredEvent } = $props();
+	import {
+		type RegisteredEvent,
+		defaultRegisteredEvent
+	} from '$lib/schema/people/filters/defaults';
+	let { item = $bindable(defaultRegisteredEvent) }: { item: RegisteredEvent } = $props();
 	import EventDropdown from '$lib/comps/widgets/events/EventDropdown.svelte';
 	import * as Select from '$lib/comps/ui/select';
 
-	const statuses: { value: FilterTypeRegisteredEvent['status']; label: string }[] = [
+	const statuses: { value: RegisteredEvent['status']; label: string }[] = [
 		{ value: 'any', label: 'Any' },
 		{ value: 'registered', label: 'Registered' },
 		{ value: 'attended', label: 'Attended' },
@@ -24,7 +27,7 @@
 		value={item.status}
 		onValueChange={(val) => {
 			if (!val) return;
-			item.status = val as FilterTypeRegisteredEvent['status'];
+			item.status = val as RegisteredEvent['status'];
 		}}
 	>
 		<Select.Trigger class="w-[180px]">

--- a/src/routes/(app)/people/filter/types/State.svelte
+++ b/src/routes/(app)/people/filter/types/State.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
 	import { page } from '$app/stores';
-	import { type FilterTypeState } from '$lib/schema/people/filters/filters';
-	let { item = $bindable() }: { item: FilterTypeState } = $props();
+	import { type State, defaultState } from '$lib/schema/people/filters/defaults';
+
+	let { item = $bindable(defaultState) }: { item: State } = $props();
 	import Input from '$lib/comps/ui/input/input.svelte';
 	import Label from '$lib/comps/ui/label/label.svelte';
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';

--- a/src/routes/(app)/people/filter/types/TypeSelector.svelte
+++ b/src/routes/(app)/people/filter/types/TypeSelector.svelte
@@ -1,7 +1,9 @@
 <script lang="ts">
 	import { page } from '$app/stores';
 	import { type FilterType } from '$lib/schema/people/filters/filters';
-	let { value = $bindable() }: { value: FilterType } = $props();
+	import { generateDefaultFilterValue } from './generateDefaultType';
+	import { type DefaultFilterTypes } from '$lib/schema/people/filters/defaults';
+	let { value = $bindable() }: { value: DefaultFilterTypes } = $props();
 	import * as Select from '$lib/comps/ui/select/';
 	const items: { value: FilterType['type']; label: string }[] = [
 		{ value: 'full_name', label: 'Full Name' },
@@ -28,7 +30,7 @@
 	{items}
 	type="single"
 	onValueChange={(val) => {
-		value.type = val as (typeof items)[0]['value'];
+		value = generateDefaultFilterValue(val as DefaultFilterTypes['type']);
 	}}
 >
 	<Select.Trigger class="md:w-[175px] w-full">

--- a/src/routes/(app)/people/filter/types/generateDefaultType.ts
+++ b/src/routes/(app)/people/filter/types/generateDefaultType.ts
@@ -1,0 +1,35 @@
+import { defaults } from '$lib/schema/people/filters/defaults';
+import { type FilterTypesOptions } from '$lib/schema/people/filters/filters';
+export function generateDefaultFilterValue(filterType: FilterTypesOptions) {
+	switch (filterType) {
+		case 'email':
+			return defaults.defaultEmail;
+		//full name is the default case
+		/* case 'full_name':
+			return defaults.defaultFullName; */
+		case 'postcode':
+			return defaults.defaultPostcode;
+		case 'locality':
+			return defaults.defaultLocality;
+		case 'state':
+			return defaults.defaultState;
+		case 'address':
+			return defaults.defaultAddress;
+		case 'phone_number':
+			return defaults.defaultPhoneNumber;
+		case 'in_list':
+			return defaults.defaultInList;
+		case 'not_in_list':
+			return defaults.defaultNotInList;
+		case 'has_tag':
+			return defaults.defaultHasTag;
+		case 'not_has_tag':
+			return defaults.defaultNotHasTag;
+		case 'registered_event':
+			return defaults.defaultRegisteredEvent;
+		case 'not_registered_event':
+			return defaults.defaultNotRegisteredEvent;
+		default:
+			return defaults.defaultFullName;
+	}
+}


### PR DESCRIPTION
The changes to the Svelte 5 APIs broke some of the advanced user filtering features. Therefore, some of the main user filtering features (albeit features that no-one was actively using) were broken in production. This PR is a fix, and also expands the robustness of the filtering widget and logic in general. 

I came across quite a few smaller issues while I was diving into this module, and this PR contains a few small patches to the general user filter feature and widgets. 