### PR TITLE
Fix/event registration status

### DIFF
--- a/src/lib/comps/ui/custom/table/DataGrid.svelte
+++ b/src/lib/comps/ui/custom/table/DataGrid.svelte
@@ -55,7 +55,7 @@
 		title?: string;
 		newItemHref?: string | null;
 		children?: Snippet;
-		content: Snippet<[T, number?]>;
+		content: Snippet<[T, number]>;
 		separator?: boolean;
 		filterKey?: string;
 		pagination?: boolean;

--- a/src/routes/(app)/events/[event_id]/+page.svelte
+++ b/src/routes/(app)/events/[event_id]/+page.svelte
@@ -1,14 +1,11 @@
 <script lang="ts">
-	export let data;
+	const { data } = $props();
 	import PageHeader from '$lib/comps/layout/PageHeader.svelte';
 	import Button from '$lib/comps/ui/button/button.svelte';
 	import DataGrid from '$lib/comps/ui/custom/table/DataGrid.svelte';
 	import PersonBadge from '$lib/comps/widgets/PersonBadge.svelte';
 	import { renderAddress } from '$lib/utils/text/address';
 	import { formatDateTimeRange, formatDate } from '$lib/utils/text/date';
-	import * as Select from '$lib/comps/ui/select';
-	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';
-	import Label from '$lib/comps/ui/label/label.svelte';
 	import MapPin from 'lucide-svelte/icons/map-pin';
 	import CalendarClock from 'lucide-svelte/icons/calendar-clock';
 	import Link from 'lucide-svelte/icons/link';
@@ -16,7 +13,7 @@
 	import { page } from '$app/stores';
 	const url = new URL(PUBLIC_HOST);
 	const previewUrl = `${url.protocol}//${$page.data.instance.slug}.${url.host}/events/${data.event.slug}`;
-
+	import EditRegistrationForm from './EditRegistrationForm.svelte';
 	import Tags from '$lib/comps/widgets/tags/Tags.svelte';
 	import PointPerson from '$lib/comps/widgets/point_person/PointPerson.svelte';
 
@@ -30,6 +27,8 @@
 		value: status,
 		label: data.t.events.status[status].title()
 	}));
+
+	const attendees = $state(data.attendees.items);
 
 	function makeStatusOptions(status: (typeof attendanceStatus)[number]) {
 		return {
@@ -81,47 +80,15 @@
 	</div>
 </div>
 <div class="mt-12">
-	<DataGrid
-		title={data.t.pages.events.attendees()}
-		items={data.attendees.items}
-		count={data.attendees.count}
-	>
-		{#snippet content(attendee: typeof data.attendees.items[0])}
+	<DataGrid title={data.t.pages.events.attendees()} items={attendees} count={data.attendees.count}>
+		{#snippet content(attendee: (typeof data.attendees.items)[0], index: number)}
 			<div class="flex items-center justify-between gap-4">
 				<PersonBadge person={attendee} />
-
-				<div>
-					<form method="post" class="flex items-center gap-2">
-						<Label>{data.t.forms.fields.events.attendees.send_notifications.label()}</Label>
-						<Checkbox bind:checked={attendee.send_notifications} />
-						<input name="send_notifications" value={attendee.send_notifications} hidden />
-						<Select.Root
-							portal={null}
-							items={statusOptions}
-							selected={makeStatusOptions(attendee.status)}
-							onSelectedChange={(v) => {
-								v && (attendee.status = v.value);
-							}}
-						>
-							<Select.Trigger class="w-[180px]">
-								<Select.Value placeholder="Status" />
-							</Select.Trigger>
-							<Select.Content>
-								<Select.Group>
-									{#each statusOptions as status}
-										<Select.Item value={status.value} label={status.label}
-											>{status.label}</Select.Item
-										>
-									{/each}
-								</Select.Group>
-							</Select.Content>
-							<Select.Input name="status" />
-						</Select.Root>
-						<input name="status" value={attendee.status} hidden />
-						<input name="person_id" value={attendee.person_id} hidden />
-						<Button type="submit" variant="outline">{data.t.forms.buttons.update()}</Button>
-					</form>
-				</div>
+				<EditRegistrationForm
+					personId={attendee.person_id}
+					status={attendee.status}
+					sendNotifications={attendee.send_notifications}
+				/>
 			</div>
 		{/snippet}
 		{#snippet headerButton()}

--- a/src/routes/(app)/events/[event_id]/EditRegistrationForm.svelte
+++ b/src/routes/(app)/events/[event_id]/EditRegistrationForm.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	const attendanceStatus: ['registered', 'attended', 'cancelled', 'noshow'] = [
+		'registered',
+		'attended',
+		'cancelled',
+		'noshow'
+	];
+	let {
+		personId,
+		sendNotifications = $bindable(),
+		status = $bindable()
+	}: {
+		personId: number;
+		sendNotifications: boolean;
+		status: (typeof attendanceStatus)[number];
+	} = $props();
+	import Button from '$lib/comps/ui/button/button.svelte';
+	import Label from '$lib/comps/ui/label/label.svelte';
+	import * as Select from '$lib/comps/ui/select';
+	import { Checkbox } from '$lib/comps/ui/checkbox';
+
+	const label = $derived($page.data.t.events.status[status]?.title() || 'Select status');
+</script>
+
+<form method="post">
+	<div class="flex items-center gap-2">
+		<input type="hidden" name="person_id" value={personId} />
+		<Label>{$page.data.t.forms.fields.events.attendees.send_notifications.label()}</Label>
+		<Checkbox bind:checked={sendNotifications} />
+		<input name="send_notifications" value={sendNotifications} hidden />
+		<input type="hidden" name="status" value={status} />
+		<Select.Root type="single" bind:value={status}>
+			<Select.Trigger class="w-[180px]">
+				{label}
+			</Select.Trigger>
+			<Select.Content>
+				<Select.Group>
+					{#each attendanceStatus as singleStatus}
+						<Select.Item value={singleStatus}
+							>{$page.data.t.events.status[singleStatus]?.title()}</Select.Item
+						>
+					{/each}
+				</Select.Group>
+			</Select.Content>
+		</Select.Root>
+		<Button variant="outline" type="submit">{$page.data.t.forms.buttons.update()}</Button>
+	</div>
+</form>

--- a/src/routes/(app)/events/[event_id]/register/RegisterPersonForm.svelte
+++ b/src/routes/(app)/events/[event_id]/register/RegisterPersonForm.svelte
@@ -38,6 +38,6 @@
 				</Select.Group>
 			</Select.Content>
 		</Select.Root>
-		<Button variant="outline" type="submit">Register</Button>
+		<Button variant="outline" type="submit">{$page.data.t.forms.buttons.save()}</Button>
 	</div>
 </form>


### PR DESCRIPTION
This updates some components relating to event registration status which were causing build issues and also was breaking functionality in the Event registration status editing panel. 

In this case, splitting out the event registration panel into a separate form component was the easiest way to make this work in the Svelte 5 reactivity model. 

We should keep an eye out for degraded functionality being caused by this. Because there are likely to be similar components affected by the same issues (binding to non-reactive variables that are declared in a snippet -- something svelte 4 made reactive using their top level let assignment magic (for more info on this read the Runes introduction here: https://svelte.dev/blog/runes). 