### PR TITLE
Updated Caddyfile to support current test instances

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,4 @@
-dashboard.belcoda.com, belcoda-test.dashboard.belcoda.com {
+dashboard.belcoda.com, belcoda-test.dashboard.belcoda.com, tayobeco.dashboard.belcoda.com, syah-seychelles.dashboard.belcoda.com, amazon-theatrix.dashboard.belcoda.com, pads4education.dashboard.belcoda.com, lyca.dashboard.belcoda.com, wave-hi.dashboard.belcoda.com, belcoda.dashboard.belcoda.com, {
   reverse_proxy app:5173  {
     header_down Strict-Transport-Security max-age=31536000;
   }


### PR DESCRIPTION
Caddy handles SSL for us, but needs subdomains to be set in Caddyfile. For now we need to manually adjust subdomains when new instances are created. In the future, we should move to a wildcard subdomain or simply to something like nginx