### PR TITLE
Fix/svelte 5 hydration issues

### DIFF
--- a/src/lib/comps/ui/custom/collapsible/collapsible.svelte
+++ b/src/lib/comps/ui/custom/collapsible/collapsible.svelte
@@ -2,7 +2,7 @@
 	import ChevronsUpDown from 'lucide-svelte/icons/chevrons-up-down';
 	import * as Collapsible from '$lib/comps/ui/collapsible/index.js';
 	import Separator from '$lib/comps/ui/separator/separator.svelte';
-	import { Button } from '$lib/comps/ui/button/index.js';
+	import { Button, buttonVariants } from '$lib/comps/ui/button/index.js';
 	import type { Snippet } from 'svelte';
 	import { cn } from '$lib/utils';
 	type Props = {
@@ -16,11 +16,9 @@
 <Collapsible.Root class={cn('space-y-2', className)}>
 	<div class="flex items-center justify-between space-x-4">
 		<h4 class="text-sm font-semibold">{@render trigger()}</h4>
-		<Collapsible.Trigger>
-			<Button variant="ghost" size="sm" class="w-9 p-0">
-				<ChevronsUpDown class="h-4 w-4" />
-				<span class="sr-only">Toggle</span>
-			</Button>
+		<Collapsible.Trigger class={cn(buttonVariants({ variant: 'ghost', size: 'sm' }), 'w-9 p-0')}>
+			<ChevronsUpDown class="h-4 w-4" />
+			<span class="sr-only">Toggle</span>
 		</Collapsible.Trigger>
 	</div>
 	<Collapsible.Content class="space-y-2">

--- a/src/routes/(app)/events/EventsForm.svelte
+++ b/src/routes/(app)/events/EventsForm.svelte
@@ -219,14 +219,22 @@
 						{form}
 						name="custom_code.custom_css"
 						label={$page.data.t.forms.fields.custom_code.custom_css.label()}
-						options={{language: 'css', lineNumbers: true, value: $formData.custom_code.custom_css as string}}
+						options={{
+							language: 'css',
+							lineNumbers: true,
+							value: $formData.custom_code.custom_css as string
+						}}
 						bind:value={$formData.custom_code.custom_css as string}
 					/>
 					<Code
 						{form}
 						name="custom_code.custom_js"
 						label={$page.data.t.forms.fields.custom_code.custom_js.label()}
-						options={{language: 'js', lineNumbers: true, value: $formData.custom_code.custom_js as string}}
+						options={{
+							language: 'js',
+							lineNumbers: true,
+							value: $formData.custom_code.custom_js as string
+						}}
 						bind:value={$formData.custom_code.custom_js as string}
 					/>
 					<Code

--- a/src/routes/(app)/events/new/+page.server.ts
+++ b/src/routes/(app)/events/new/+page.server.ts
@@ -13,7 +13,10 @@ import { create, read } from '$lib/schema/events/events';
 import { parse } from '$lib/schema/valibot';
 const log = pino('(app)/events/new/+page.server.ts');
 export async function load(event) {
-	const form = await superValidate(valibot(create));
+	const form = await superValidate(
+		{ ...event.locals.instance.settings.events.default_event_info_settings },
+		valibot(create)
+	);
 	return { form };
 }
 

--- a/src/routes/(app)/petitions/new/+page.server.ts
+++ b/src/routes/(app)/petitions/new/+page.server.ts
@@ -14,7 +14,10 @@ import { create, read } from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
 const log = pino('(app)/events/new/+page.server.ts');
 export async function load(event) {
-	const form = await superValidate(valibot(create));
+	const form = await superValidate(
+		{ ...event.locals.instance.settings.events.default_event_info_settings },
+		valibot(create)
+	);
 	return { form };
 }
 


### PR DESCRIPTION
A few small issues with Svelte 5 were causing errors on event and petition creation screens. This is because checkboxes now throw an error if they are set to undefined in Svelte 5. I added the default from the instance event user info collection settings (which are the same values as petition user info collection settings) as the initial values on new event and petition creation. 

In the future, we should explicitly set the petition defaults to be from a petition setting, in case the values diverge down the track -- it could be annoying to debug. 

I also fixed the "Collapsible" component, which used a button as the trigger element. ShadCN's Svelte 5 version has a button in the base component, which now leads to hydration mismatches as `<button>` cannot be within another `<button>` element, and the browser fixes the html, which leads to a hydration miss. 

This patch fixes both issues and should be deployed quicky as event creation in production is currently broken. 