### PR TITLE
Add bagde variants

### DIFF
--- a/src/lib/comps/ui/badge/badge.svelte
+++ b/src/lib/comps/ui/badge/badge.svelte
@@ -10,7 +10,10 @@
 					'bg-secondary text-secondary-foreground hover:bg-secondary/80 border-transparent',
 				destructive:
 					'bg-destructive text-destructive-foreground hover:bg-destructive/80 border-transparent',
-				outline: 'text-foreground'
+				outline: 'text-foreground',
+				success: 'bg-success-400 text-success-foreground hover:bg-success/80 border-transparent',
+				warning: 'bg-warning-400 text-warning-foreground hover:bg-warning/80 border-transparent',
+				danger: 'bg-danger-400 text-danger-foreground hover:bg-danger/80 border-transparent'
 			}
 		},
 		defaultVariants: {


### PR DESCRIPTION
This adds success, warning and danger badge variants.

Before:
![image](https://github.com/user-attachments/assets/153e9785-4386-4dd7-941f-27002cba2322)

After:
![image](https://github.com/user-attachments/assets/7f1dbd92-3b98-4d81-98c7-822153e42d6d)

![image](https://github.com/user-attachments/assets/b988ba0a-9f24-4471-a090-528c30dc7e5b)

![image](https://github.com/user-attachments/assets/ab2189eb-7563-483b-9cec-bb27ff85a9a0)
