### PR TITLE
Removed --force option from npm install in build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY ./tsconfig.json ./
 COPY ./svelte.config.js ./
 COPY ./vite.config.ts ./
 COPY ./.env.production ./.env
-RUN npm install --force
+RUN npm install
 COPY . .
 ENV NODE_OPTIONS=--max_old_space_size=1800
 RUN npm run build
@@ -15,7 +15,7 @@ COPY --from=build /app/build .
 COPY --from=build /app/package.json .
 COPY --from=build /app/package-lock.json .
 COPY --from=build /app/.env.production .env
-RUN npm ci --omit dev --force
-RUN npm i dotenv --force
+RUN npm ci --omit dev
+RUN npm i dotenv
 EXPOSE 3000
 CMD ["npm", "run", "start:production"]


### PR DESCRIPTION
Previously, when we were using Svelte 5 beta, but most components and libraries were using Svelte 4, we had lots of peer dependency conflicts happening, and npm i --force was the only way to install any packages.

Luckily, this was fixed some time ago. I just noticed that the --force flag was still being used in the build scripts, however.