### PR TITLE
Added DO cert to staging db configuration

### DIFF
--- a/knexfile.cjs
+++ b/knexfile.cjs
@@ -22,7 +22,12 @@ module.exports = {
 
 	staging: {
 		client: 'postgresql',
-		connection: process.env.STAGING_DATABASE_URL,
+		connection: {
+			connectionString: process.env.STAGING_DATABASE_URL,
+			ssl: {
+				ca: fs.readFileSync(path.join(__dirname, './ca-certificate.crt')) //needed for SSL in some database providers
+			}
+		},
 		pool: {
 			min: 2,
 			max: 10


### PR DESCRIPTION
This is in preparation of establishing a staging environment. We'll use the same managed database service to make sure the environment is as close as possible -- so we'll need to include their SSL cert. 