### PR TITLE
Feature/edit website config info

### DIFF
--- a/src/lib/comps/ui/custom/pagination/pagination.svelte
+++ b/src/lib/comps/ui/custom/pagination/pagination.svelte
@@ -12,15 +12,15 @@
 		showOnSinglePage?: boolean;
 		loading: boolean;
 	} = $props();
-	import { MediaQuery } from 'runed';
-	const isDesktop = new MediaQuery('(min-width: 768px)');
+	import { MediaQuery } from 'svelte/reactivity';
+	const isDesktop = new MediaQuery('min-width: 768px');
 
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	const perPage = $state(Number($page.url.searchParams.get('perPage')) || 25);
 	const initialPage = $state(Number($page.url.searchParams.get('page')) || 1);
-	const siblingCount = $derived(isDesktop.matches ? 1 : 0);
+	const siblingCount = $derived(isDesktop.current ? 1 : 0);
 	async function handlePageChange(newPage: number) {
 		//set the params... invalidate;
 		if (browser) {

--- a/src/lib/comps/ui/form/controls/file_upload/file_upload.svelte
+++ b/src/lib/comps/ui/form/controls/file_upload/file_upload.svelte
@@ -10,7 +10,6 @@
 	import AlertTriangle from 'lucide-svelte/icons/triangle-alert';
 	const file_upload_widget_id = crypto.randomUUID();
 	import { createEventDispatcher } from 'svelte';
-	import { file } from 'valibot';
 	const dispatch = createEventDispatcher();
 
 	export let label: string | null = null;

--- a/src/lib/comps/ui/form/controls/file_upload/simple_image_upload.svelte
+++ b/src/lib/comps/ui/form/controls/file_upload/simple_image_upload.svelte
@@ -1,0 +1,123 @@
+<script lang="ts">
+	// This is a simple image upload component that bypasses the normal uploads system.
+	// It directly uploads an image to the designated S3 public bucket and returns the URL.
+	const DEFAULT_FILE_TYPES: string[] = [
+		'image/png',
+		'image/jpeg',
+		'image/jpg',
+		'image/gif',
+		'image/webp',
+		'image/svg+xml'
+	];
+
+	import { cn } from '$lib/utils';
+	import { PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME } from '$env/static/public';
+	import { page } from '$app/stores';
+
+	const {
+		onUpload,
+		file_types = DEFAULT_FILE_TYPES,
+		label,
+		description
+	}: {
+		onUpload: ({ url, type, size }: { url: string; type: string; size: number }) => void;
+		file_types: string[];
+		label: string;
+		description: string;
+	} = $props();
+
+	import Loader from 'lucide-svelte/icons/loader';
+	import CheckCircle from 'lucide-svelte/icons/circle-check';
+	import Input from '$lib/comps/ui/input/input.svelte';
+	import * as Alert from '$lib/comps/ui/alert';
+	import AlertTriangle from 'lucide-svelte/icons/triangle-alert';
+
+	import {
+		getAndCheckFile,
+		renameFile,
+		getSignedURL,
+		uploadToS3
+	} from '$lib/comps/ui/form/controls/file_upload/upload';
+	import { randomUUID } from 'crypto';
+	const file_upload_widget_id = randomUUID();
+	const MAXIMUM_FILE_SIZE: number = 10485760; //~10mb
+	const bucket_url = `https://${PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME}.s3.amazonaws.com`;
+
+	const acceptable_file_types = file_types.join(', ');
+
+	let loading = $state(false);
+	let error: string | null = $state(null);
+	let disabled = $state(false);
+	let success = $state(false);
+
+	async function handleUpload() {
+		try {
+			//reset
+			error = null;
+			success = false;
+			//start process
+			disabled = true;
+			loading = true;
+			const input = document.getElementById(file_upload_widget_id) as HTMLInputElement;
+			const file = getAndCheckFile({
+				fileInput: input,
+				t: $page.data.t,
+				maxFileSize: MAXIMUM_FILE_SIZE,
+				allowedTypes: file_types
+			});
+			const fileToUpload = await renameFile(file);
+
+			const signedURL = await getSignedURL(fileToUpload, $page.data.t);
+
+			const awsPathName = await uploadToS3({
+				file: fileToUpload,
+				signedURL: signedURL,
+				t: $page.data.t
+			});
+			const uploadedUrl = `${bucket_url}${awsPathName}`; //this is the URL to the uploaded file, no / needed
+			onUpload({ url: uploadedUrl, type: file.type, size: file.size });
+			success = true;
+		} catch (err) {
+			error = err instanceof Error ? err.message : $page.data.t.errors.file_upload.upload_error();
+			console.error(err);
+		} finally {
+			disabled = false;
+			loading = false;
+		}
+	}
+</script>
+
+{#if label}<label
+		class="block mb-2 text-sm font-medium text-gray-900 dark:text-white"
+		for={file_upload_widget_id}>{label}</label
+	>{/if}
+<div class="flex items-center gap-2">
+	<Input
+		onchange={handleUpload}
+		{disabled}
+		accept={acceptable_file_types}
+		class={cn(
+			'block w-full text-sm text-gray-900 border border-gray-300 rounded-lg cursor-pointer bg-gray-50 dark:text-gray-400 focus:outline-none dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400'
+		)}
+		aria-describedby="file_input_help"
+		id="file_input"
+		type="file"
+	/>
+	{#if loading}<Loader class="animate animate-spin" />{/if}
+	{#if success}<CheckCircle />{/if}
+</div>
+{#if description}
+	<p class="mt-1 text-sm text-gray-500 dark:text-gray-300" id={file_upload_widget_id}>
+		{description}
+	</p>
+{/if}
+
+{#if error}
+	<Alert.Root variant="destructive" class="mt-1">
+		<AlertTriangle class="h-4 w-4" />
+		<Alert.Title>{$page.data.t.errors.generic()}</Alert.Title>
+		<Alert.Description>
+			{error}
+		</Alert.Description>
+	</Alert.Root>
+{/if}

--- a/src/lib/comps/ui/form/controls/file_upload/upload.test.ts
+++ b/src/lib/comps/ui/form/controls/file_upload/upload.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest';
+import { checkFileSize, checkFileType } from '$lib/comps/ui/form/controls/file_upload/upload';
+import { Localization } from '$lib/i18n';
+
+const t = new Localization('en');
+
+describe('checkFileType', () => {
+	it('should not throw an error if file type is allowed', () => {
+		const file = new File([], 'test.jpg', { type: 'image/jpeg' });
+		expect(() => checkFileType(file, t, ['image/jpeg', 'image/png'])).not.toThrow();
+	});
+
+	it('should throw an error if file type is not allowed', () => {
+		const file = new File([], 'test.txt', { type: 'text/plain' });
+		expect(() => checkFileType(file, t, ['image/jpeg', 'image/png'])).toThrowError(
+			t.errors.file_upload.unsupported_type('image/jpeg, image/png')
+		);
+	});
+
+	it('should include all allowed types in the error message', () => {
+		const file = new File([], 'test.pdf', { type: 'application/pdf' });
+		expect(() => checkFileType(file, t, ['image/jpeg', 'image/png', 'text/plain'])).toThrowError(
+			t.errors.file_upload.unsupported_type('image/jpeg, image/png, text/plain')
+		);
+	});
+});
+
+describe('checkFileSize', () => {
+	it('should not throw an error if file size is within limit', () => {
+		const file = createFileFromBuffer(1024, 'test.jpg'); // 1.0 KiB
+		expect(() => checkFileSize(file, t, 2048)).not.toThrow();
+	});
+
+	it('should throw an error if file size exceeds limit', () => {
+		const file = createFileFromBuffer(5 * 1024, 'test.jpg'); // 5.0 KiB
+		expect(() => checkFileSize(file, t, 2048)).toThrowError(
+			t.errors.file_upload.too_large('2.0 KiB')
+		);
+	});
+
+	it('should format the max size correctly in the error message', () => {
+		const file = createFileFromBuffer(5000000, 'test.jpg');
+		expect(
+			() => checkFileSize(file, t, 1024 * 1024) // 1 MiB
+		).toThrowError(t.errors.file_upload.too_large('1.0 MiB'));
+	});
+});
+
+export function createFileFromBuffer(sizeInBytes: number, fileName: string): File {
+	// Generate a random buffer of the specified size
+	const buffer = new Uint8Array(sizeInBytes);
+
+	// Fill the buffer with random data (for simplicity, using random byte values)
+	for (let i = 0; i < sizeInBytes; i++) {
+		buffer[i] = Math.floor(Math.random() * 256); // Random byte (0-255)
+	}
+
+	// Create a Blob from the buffer
+	const blob = new Blob([buffer], { type: 'application/octet-stream' });
+
+	// Create a File from the Blob, with the provided name
+	return new File([blob], fileName, { type: 'application/octet-stream' });
+}

--- a/src/lib/comps/ui/form/controls/file_upload/upload.ts
+++ b/src/lib/comps/ui/form/controls/file_upload/upload.ts
@@ -1,0 +1,85 @@
+import { isBigger } from '$lib/utils/math/number';
+import { humanReadableFileSize } from '$lib/utils/text/file_size';
+export function getAndCheckFile({
+	fileInput,
+	t,
+	maxFileSize,
+	allowedTypes
+}: {
+	fileInput: HTMLInputElement;
+	t: App.Localization;
+	maxFileSize: number;
+	allowedTypes: string[];
+}): File {
+	const files = fileInput.files;
+	if (!files) throw new Error(t.errors.file_upload.no_file_selected());
+	const file = files[files.length - 1];
+	checkFileSize(file, t, maxFileSize);
+	checkFileType(file, t, allowedTypes);
+	return file;
+}
+
+export function checkFileSize(file: File, t: App.Localization, maxFileSize: number): void {
+	if (isBigger(file.size, maxFileSize)) {
+		throw new Error(t.errors.file_upload.too_large(humanReadableFileSize(maxFileSize)));
+	}
+}
+
+export function checkFileType(file: File, t: App.Localization, allowedTypes: string[]): void {
+	if (!allowedTypes.includes(file.type)) {
+		throw new Error(t.errors.file_upload.unsupported_type(allowedTypes.join(', ')));
+	}
+}
+import { randomUUID } from 'crypto';
+export function renameFile(file: File): File {
+	const uploadableName = `${randomUUID()}-${file.name}`; // Add a random UUID to the file name to avoid conflicts
+	return new File([file], uploadableName, { type: file.type });
+}
+export async function getSignedURL(file: File, t: App.Localization): Promise<string> {
+	const site_uploads_url: string = '/api/v1/website/uploads/link';
+	const push_file_request_response = await fetch(site_uploads_url, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify({
+			file_name: file.name
+		})
+	});
+	if (!push_file_request_response.ok) {
+		console.error(await push_file_request_response.json());
+		throw new Error(t.errors.file_upload.upload_error());
+	}
+	const push_file_request_body = await push_file_request_response.json();
+	const put_url = push_file_request_body.put_url;
+	if (!put_url) {
+		console.error(`No put_url in response: ${push_file_request_body}`);
+		throw new Error(t.errors.file_upload.upload_error());
+	}
+	return put_url;
+}
+
+export async function uploadToS3({
+	file,
+	signedURL,
+	t
+}: {
+	file: File;
+	signedURL: string;
+	t: App.Localization;
+}): Promise<string> {
+	//upload the file to the signed url
+	const aws_response = await fetch(signedURL, {
+		method: 'put',
+		body: file
+	});
+
+	if (!aws_response.ok) {
+		console.error('file upload failed');
+		console.error(await aws_response.text());
+		throw new Error(t.errors.file_upload.upload_error());
+	}
+
+	const awsPath = new URL(aws_response.url).pathname; // Get the path of the uploaded file on AWS that we will add to our bucket URL
+	return awsPath;
+}

--- a/src/lib/comps/ui/form/controls/file_upload/upload.ts
+++ b/src/lib/comps/ui/form/controls/file_upload/upload.ts
@@ -30,9 +30,9 @@ export function checkFileType(file: File, t: App.Localization, allowedTypes: str
 		throw new Error(t.errors.file_upload.unsupported_type(allowedTypes.join(', ')));
 	}
 }
-import { randomUUID } from 'crypto';
+import { v4 as uuidv4 } from 'uuid';
 export function renameFile(file: File): File {
-	const uploadableName = `${randomUUID()}-${file.name}`; // Add a random UUID to the file name to avoid conflicts
+	const uploadableName = `${uuidv4()}-${file.name}`; // Add a random UUID to the file name to avoid conflicts
 	return new File([file], uploadableName, { type: file.type });
 }
 export async function getSignedURL(file: File, t: App.Localization): Promise<string> {

--- a/src/lib/i18n/localizations/forms.ts
+++ b/src/lib/i18n/localizations/forms.ts
@@ -148,6 +148,20 @@ export default function (locale: SL) {
 						});
 					}
 				},
+				url: {
+					label: () => {
+						return t(locale, {
+							en: 'URL',
+							ja: 'URL',
+							pt: 'URL',
+							es: 'URL',
+							fr: 'URL',
+							sw: 'URL',
+							th: 'URL',
+							zh: 'URL'
+						});
+					}
+				},
 				title: {
 					label: () => {
 						return t(locale, {
@@ -1960,6 +1974,178 @@ export default function (locale: SL) {
 								sw: 'Chagua lugha',
 								th: 'เลือกภาษา',
 								zh: '选择语言'
+							});
+						}
+					}
+				},
+				website: {
+					custom_domain: {
+						label: () => {
+							return t(locale, {
+								en: 'Custom Domain',
+								ja: 'カスタムドメイン',
+								pt: 'Domínio Personalizado',
+								es: 'Dominio Personalizado',
+								fr: 'Domaine Personnalisé',
+								sw: 'Kikoa cha Kipekee',
+								th: 'โดเมนที่กำหนดเอง',
+								zh: '自定义域名'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'Enter a custom subdomain that will be accessed by your users. For details on how to set up a custom domain, see our documentation.',
+								ja: 'ユーザーがアクセスするカスタムサブドメインを入力してください。カスタムドメインの設定方法の詳細については、ドキュメントを参照してください。',
+								pt: 'Digite um subdomínio personalizado que será acessado por seus usuários. Para obter detalhes sobre como configurar um domínio personalizado, consulte nossa documentação.',
+								es: 'Ingrese un subdominio personalizado al que accederán sus usuarios. Para obtener detalles sobre cómo configurar un dominio personalizado, consulte nuestra documentación.',
+								fr: 'Entrez un sous-domaine personnalisé qui sera accessible par vos utilisateurs. Pour plus de détails sur la configuration d’un domaine personnalisé, consultez notre documentation.',
+								sw: 'Ingiza kikoa cha kipekee ambacho kitatumika na watumiaji wako. Kwa maelezo kuhusu jinsi ya kuweka kikoa cha kipekee, angalia nyaraka zetu.',
+								th: 'ป้อนโดเมนย่อยที่กำหนดเองที่ผู้ใช้ของคุณจะเข้าถึง สำหรับรายละเอียดเกี่ยวกับวิธีตั้งค่าโดเมนที่กำหนดเอง ดูเอกสารของเรา',
+								zh: '输入用户将访问的自定义子域。有关如何设置自定义域的详细信息，请参阅我们的文档。'
+							});
+						}
+					},
+					logo: {
+						label: () => {
+							return t(locale, {
+								en: 'Logo',
+								ja: 'ロゴ',
+								pt: 'Logotipo',
+								es: 'Logotipo',
+								fr: 'Logo',
+								sw: 'Alama',
+								th: 'โลโก้',
+								zh: '商标'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'The logo for your organization. Ideally, this should be at least 500px wide by 100px tall, and in PNG or SVG format. It will be displayed in the header of your website.',
+								ja: '組織のロゴです。理想的には、幅500px、高さ100px以上で、PNGまたはSVG形式であるべきです。ウェブサイトのヘッダーに表示されます。',
+								pt: 'O logotipo da sua organização. Idealmente, ele deve ter pelo menos 500px de largura por 100px de altura, e no formato PNG ou SVG. Ele será exibido no cabeçalho do seu site.',
+								es: 'El logotipo de su organización. Idealmente, debe tener al menos 500px de ancho por 100px de alto, y en formato PNG o SVG. Se mostrará en el encabezado de su sitio web.',
+								fr: 'Le logo de votre organisation. Idéalement, il devrait mesurer au moins 500px de large par 100px de haut, et être au format PNG ou SVG. Il sera affiché dans l’en-tête de votre site Web.',
+								sw: 'Alama ya shirika lako. Kwa kawaida, hii inapaswa kuwa angalau upana wa 500px kwa urefu wa 100px, na katika muundo wa PNG au SVG. Itaonyeshwa kwenye kichwa cha tovuti yako.',
+								th: 'โลโก้สำหรับองค์กรของคุณ อย่างไรก็ตาม ควรมีความกว้างอย่างน้อย 500px โดย 100px สูง และในรูปแบบ PNG หรือ SVG จะแสดงในส่วนหัวของเว็บไซต์ของคุณ',
+								zh: '您的组织标志。理想情况下，宽度至少为 500px，高度为 100px，并且为 PNG 或 SVG 格式。它将显示在您网站的页眉中。'
+							});
+						}
+					},
+					favicon: {
+						label: () => {
+							return t(locale, {
+								en: 'Favicon',
+								ja: 'ファビコン',
+								pt: 'Favicon',
+								es: 'Favicon',
+								fr: 'Favicon',
+								sw: 'Favicon',
+								th: 'ไอคอนเว็บ',
+								zh: '网站图标'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'A small icon that represents your organization. It will be displayed in the browser tab when users visit your website.',
+								ja: '組織を表す小さなアイコンです。ユーザーがウェブサイトを訪れると、ブラウザのタブに表示されます。',
+								pt: 'Um pequeno ícone que representa sua organização. Ele será exibido na guia do navegador quando os usuários visitarem seu site.',
+								es: 'Un pequeño icono que representa a su organización. Se mostrará en la pestaña del navegador cuando los usuarios visiten su sitio web.',
+								fr: 'Une petite icône qui représente votre organisation. Il sera affiché dans l’onglet du navigateur lorsque les utilisateurs visitent votre site Web.',
+								sw: 'Alama ndogo inayowakilisha shirika lako. Itaonyeshwa kwenye kichupo cha kivinjari wakati watumiaji wanapozuru tovuti yako.',
+								th: 'ไอคอนขนาดเล็กที่แสดงถึงองค์กรของคุณ จะแสดงในแท็บของเบราว์เซอร์เมื่อผู้ใช้เข้าชมเว็บไซต์ของคุณ',
+								zh: '代表您的组织的小图标。当用户访问您的网站时，它将显示在浏览器选项卡中。'
+							});
+						}
+					},
+					header_links: {
+						title: () => {
+							return t(locale, {
+								en: 'Header Links',
+								ja: 'ヘッダーリンク',
+								pt: 'Links do Cabeçalho',
+								es: 'Enlaces del Encabezado',
+								fr: 'Liens de l’En-tête',
+								sw: 'Viungo vya Kichwa',
+								th: 'ลิงก์ด้านบน',
+								zh: '页眉链接'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'Links that will be displayed in the header of your website.',
+								ja: 'ウェブサイトのヘッダーに表示されるリンクです。',
+								pt: 'Links que serão exibidos no cabeçalho do seu site.',
+								es: 'Enlaces que se mostrarán en el encabezado de su sitio web.',
+								fr: 'Liens qui seront affichés dans l’en-tête de votre site Web.',
+								sw: 'Viungo ambavyo vitaonyeshwa kwenye kichwa cha tovuti yako.',
+								th: 'ลิงก์ที่จะแสดงในส่วนหัวของเว็บไซต์ของคุณ',
+								zh: '将显示在您网站页眉中的链接。'
+							});
+						}
+					},
+					open_in_new_tab: {
+						label: () => {
+							return t(locale, {
+								en: 'Open in new tab',
+								ja: '新しいタブで開く',
+								pt: 'Abrir em nova aba',
+								es: 'Abrir en una nueva pestaña',
+								fr: 'Ouvrir dans un nouvel onglet',
+								sw: 'Fungua kwenye kichupo kipya',
+								th: 'เปิดในแท็บใหม่',
+								zh: '在新标签页中打开'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'Should the link open in a new tab?',
+								ja: 'リンクは新しいタブで開きますか？',
+								pt: 'O link deve abrir em uma nova aba?',
+								es: '¿El enlace debe abrirse en una nueva pestaña?',
+								fr: 'Le lien doit-il s’ouvrir dans un nouvel onglet?',
+								sw: 'Je, kiungo kifunguliwe kwenye kichupo kipya?',
+								th: 'ควรเปิดลิงก์ในแท็บใหม่หรือไม่?',
+								zh: '链接是否应在新标签页中打开？'
+							});
+						}
+					},
+					add_link: {
+						label: () => {
+							return t(locale, {
+								en: 'Add a link',
+								ja: 'リンクを追加',
+								pt: 'Adicionar um link',
+								es: 'Agregar un enlace',
+								fr: 'Ajouter un lien',
+								sw: 'Ongeza kiungo',
+								th: 'เพิ่มลิงก์',
+								zh: '添加链接'
+							});
+						}
+					},
+					footer_links: {
+						title: () => {
+							return t(locale, {
+								en: 'Footer Links',
+								ja: 'フッターリンク',
+								pt: 'Links do Rodapé',
+								es: 'Enlaces del Pie de Página',
+								fr: 'Liens du Pied de Page',
+								sw: 'Viungo vya Chini',
+								th: 'ลิงก์ด้านล่าง',
+								zh: '页脚链接'
+							});
+						},
+						description: () => {
+							return t(locale, {
+								en: 'Links that will be displayed in the footer of your website.',
+								ja: 'ウェブサイトのフッターに表示されるリンクです。',
+								pt: 'Links que serão exibidos no rodapé do seu site.',
+								es: 'Enlaces que se mostrarán en el pie de página de su sitio web.',
+								fr: 'Liens qui seront affichés dans le pied de page de votre site Web.',
+								sw: 'Viungo ambavyo vitaonyeshwa kwenye chini ya tovuti yako.',
+								th: 'ลิงก์ที่จะแสดงในส่วนท้ายของเว็บไซต์ของคุณ',
+								zh: '将显示在您网站页脚中的链接。'
 							});
 						}
 					}

--- a/src/lib/schema/core/instance.ts
+++ b/src/lib/schema/core/instance.ts
@@ -8,7 +8,8 @@ import {
 	timestamp,
 	shortString,
 	email,
-	longStringNotEmpty
+	longStringNotEmpty,
+	domainName
 } from '$lib/schema/valibot';
 
 export const settings = v.object({
@@ -44,7 +45,7 @@ export const settings = v.object({
 	}),
 	website: v.object({
 		default_template_id: id,
-		custom_domain: v.nullable(shortString), //if custom domain is null, the the website will be https://${instance.slug}.{PUBLIC_ROOT_DOMAIN}. Otherwise, it will be https://${customDomain}
+		custom_domain: v.nullable(domainName), //if custom domain is null, the the website will be https://${instance.slug}.{PUBLIC_ROOT_DOMAIN}. Otherwise, it will be https://${customDomain}
 		pages_content_type_id: id,
 		posts_content_type_id: id,
 		logo_url: url,
@@ -103,7 +104,9 @@ export type List = v.InferOutput<typeof list>;
 export const create = v.omit(read, ['id', 'created_at', 'updated_at']);
 export type Create = v.InferOutput<typeof create>;
 
-export const update = v.partial(v.omit(base, ['id', 'created_at', 'updated_at']));
+export const update = v.partial(
+	v.omit(base, ['id', 'name', 'slug', 'country', 'installed', 'created_at', 'updated_at'])
+);
 export type Update = v.InferInput<typeof update>;
 
 export const updateSecrets = v.object({

--- a/src/lib/schema/valibot.ts
+++ b/src/lib/schema/valibot.ts
@@ -69,6 +69,12 @@ export const slug = v.pipe(
 	v.maxLength(SHORT_STRING_MAX_LENGTH),
 	v.regex(SLUG_REGEXP)
 );
+//taken from https://github.com/fabian-hiller/valibot/pull/907/commits/27efeef44cd8f1e7e7ee37ea65e4d8c3836ab2fd
+export const domainName = v.pipe(
+	v.string(),
+	v.regex(/^(?!-)([a-z0-9-]{1,63}(?<!-)\.)+[a-z]{2,6}$/iu)
+);
+
 export const email = v.pipe(v.string(), v.email());
 export const url = v.pipe(v.string(), v.maxLength(LONG_STRING_MAX_LENGTH)); //currently JSON schema library doesn't support URL verification
 export const uuid = v.pipe(v.string(), v.uuid());

--- a/src/lib/utils/math/number.test.ts
+++ b/src/lib/utils/math/number.test.ts
@@ -1,0 +1,76 @@
+import { isBigger } from '$lib/utils/math/number';
+import { expect, it, describe } from 'vitest';
+
+describe('isBigger', () => {
+	it('should return true if a is bigger than b', () => {
+		expect(isBigger(2, 1)).toBe(true);
+	});
+
+	it('should return false if a is smaller than b', () => {
+		expect(isBigger(1, 2)).toBe(false);
+	});
+
+	it('should return false if a is equal to b', () => {
+		expect(isBigger(1, 1)).toBe(false);
+	});
+
+	it('should return false if a is a negative number and b is a positive number', () => {
+		expect(isBigger(-1, 1)).toBe(false);
+	});
+
+	it('should return true if a is a positive number and b is a negative number', () => {
+		expect(isBigger(1, -1)).toBe(true);
+	});
+
+	it("shouldn't be tricked by floating point precision", () => {
+		expect(isBigger(0.1 + 0.2, 0.3)).toBe(true);
+	});
+
+	it('should return false if a is NaN', () => {
+		expect(isBigger(NaN, 1)).toBe(false);
+	});
+
+	it('should return false if b is NaN', () => {
+		expect(isBigger(1, NaN)).toBe(false);
+	});
+
+	it('should return false if a and b are NaN', () => {
+		expect(isBigger(NaN, NaN)).toBe(false);
+	});
+
+	it('should return true if a is Infinity', () => {
+		expect(isBigger(Infinity, 1)).toBe(true);
+	});
+
+	it('should return false if b is Infinity', () => {
+		expect(isBigger(1, Infinity)).toBe(false);
+	});
+
+	it('should return false if a is -Infinity', () => {
+		expect(isBigger(-Infinity, 1)).toBe(false);
+	});
+
+	it('should return true if b is -Infinity', () => {
+		expect(isBigger(1, -Infinity)).toBe(true);
+	});
+
+	it('should return false if a is -Infinity and b is Infinity', () => {
+		expect(isBigger(-Infinity, Infinity)).toBe(false);
+	});
+
+	it('should return true if a is Infinity and b is -Infinity', () => {
+		expect(isBigger(Infinity, -Infinity)).toBe(true);
+	});
+
+	it('should return false if a is -0', () => {
+		expect(isBigger(-0, 0)).toBe(false);
+	});
+
+	it('should return false if b is -0', () => {
+		expect(isBigger(0, -0)).toBe(false);
+	});
+
+	it("shouldn't be tricked by integer overflows", () => {
+		expect(isBigger(9007199254740991, 9007199254740992)).toBe(false);
+	});
+});

--- a/src/lib/utils/math/number.ts
+++ b/src/lib/utils/math/number.ts
@@ -1,0 +1,12 @@
+export function isBigger(a: number, b: number): boolean {
+	// Handle NaN cases
+	if (isNaN(a) || isNaN(b)) return false;
+
+	// Handle Infinity and -Infinity
+	if (!isFinite(a) || !isFinite(b)) {
+		return a > b;
+	}
+
+	// Handle normal comparisons
+	return a > b;
+}

--- a/src/lib/utils/text/file_size.test.ts
+++ b/src/lib/utils/text/file_size.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { humanReadableFileSize } from '$lib/utils/text/file_size'; // Adjust the path as necessary
+
+describe('humanReadableFileSize', () => {
+	it('should return "0 B" for 0 bytes', () => {
+		expect(humanReadableFileSize(0)).toBe('0 B');
+	});
+
+	it('should return bytes in base 1024 by default', () => {
+		expect(humanReadableFileSize(500)).toBe('500 B');
+		expect(humanReadableFileSize(1024)).toBe('1.0 KiB');
+		expect(humanReadableFileSize(1536)).toBe('1.5 KiB');
+	});
+
+	it('should return bytes in SI base 1000 when `si` is true', () => {
+		expect(humanReadableFileSize(500, true)).toBe('500 B');
+		expect(humanReadableFileSize(1000, true)).toBe('1.0 kB');
+		expect(humanReadableFileSize(1500, true)).toBe('1.5 kB');
+	});
+
+	it('should handle larger units in base 1024', () => {
+		expect(humanReadableFileSize(1048576)).toBe('1.0 MiB');
+		expect(humanReadableFileSize(1073741824)).toBe('1.0 GiB');
+		expect(humanReadableFileSize(1099511627776)).toBe('1.0 TiB');
+	});
+
+	it('should handle larger units in SI base 1000', () => {
+		expect(humanReadableFileSize(1000000, true)).toBe('1.0 MB');
+		expect(humanReadableFileSize(1000000000, true)).toBe('1.0 GB');
+		expect(humanReadableFileSize(1000000000000, true)).toBe('1.0 TB');
+	});
+
+	it('should round to the specified number of decimal places', () => {
+		expect(humanReadableFileSize(1536, false, 2)).toBe('1.50 KiB');
+		expect(humanReadableFileSize(1500, true, 2)).toBe('1.50 kB');
+		expect(humanReadableFileSize(1048576, false, 0)).toBe('1 MiB');
+	});
+
+	it('should handle negative byte values', () => {
+		expect(humanReadableFileSize(-1024)).toBe('-1.0 KiB');
+		expect(humanReadableFileSize(-1500, true)).toBe('-1.5 kB');
+	});
+
+	it('should handle edge cases for small values close to thresholds', () => {
+		expect(humanReadableFileSize(1023, false)).toBe('1023 B');
+		expect(humanReadableFileSize(999, true)).toBe('999 B');
+	});
+
+	it('should handle extremely large values', () => {
+		expect(humanReadableFileSize(1e24, true)).toBe('1.0 YB'); // Yottabytes in SI
+		expect(humanReadableFileSize(2 ** 80, false)).toBe('1.0 YiB'); // Yobibytes in base 1024
+	});
+});

--- a/src/routes/(api)/api/v1/settings/organization/+server.ts
+++ b/src/routes/(api)/api/v1/settings/organization/+server.ts
@@ -1,0 +1,18 @@
+import { json, error } from '$lib/server';
+import { parse } from '$lib/schema/valibot';
+import { update } from '$lib/schema/core/instance';
+import { update as updateApi } from '$lib/server/api/core/instances';
+export async function PUT(event) {
+	try {
+		const body = await event.request.json();
+		const parsed = parse(update, body);
+		const updated = await updateApi({
+			instanceId: event.locals.instance.id,
+			body: parsed,
+			t: event.locals.t
+		});
+		return json(updated);
+	} catch (err) {
+		return error(500, 'API:/settings/organization:PUT', event.locals.t.errors.http[500](), err);
+	}
+}

--- a/src/routes/(app)/settings/website/+page.server.ts
+++ b/src/routes/(app)/settings/website/+page.server.ts
@@ -1,0 +1,25 @@
+import { valibot, superValidate, formAction, redirect } from '$lib/server';
+import { update, read } from '$lib/schema/core/instance';
+import { parse } from '$lib/schema/valibot';
+
+export async function load(event) {
+	const form = await superValidate(event.locals.instance, valibot(update));
+	return { form };
+}
+
+export const actions = {
+	default: async function (event) {
+		const output = await formAction({
+			event,
+			url: '/api/v1/settings/organization',
+			method: 'PUT',
+			inputSchema: update
+		});
+		if (output.error) return output.output;
+		const parsed = parse(read, output.output);
+		event.locals.instance = parsed;
+		return redirect(event, {
+			message: event.locals.t.forms.actions.saved()
+		});
+	}
+};

--- a/src/routes/(app)/settings/website/+page.svelte
+++ b/src/routes/(app)/settings/website/+page.svelte
@@ -4,9 +4,12 @@
 	import * as Card from '$lib/comps/ui/card';
 	import Button from '$lib/comps/ui/button/button.svelte';
 	import Grid from '$lib/comps/ui/custom/grid.svelte';
+	import WebsiteConfigForm from './WebsiteConfigForm.svelte';
+	const { data } = $props();
 </script>
 
 <PageHeader title={$page.data.t.pages.config.settings.website.index()} />
+<div class="mt-6"><WebsiteConfigForm superform={data.form} /></div>
 
 <Grid cols={1}>
 	<Card.Root class="mt-4">

--- a/src/routes/(app)/settings/website/WebsiteConfigForm.svelte
+++ b/src/routes/(app)/settings/website/WebsiteConfigForm.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+	import { update, type Settings } from '$lib/schema/core/instance';
+	import { type SuperValidated } from 'sveltekit-superforms';
+	import {
+		Button,
+		Error,
+		Input,
+		Grid,
+		Debug,
+		superForm,
+		valibotClient,
+		type Infer
+	} from '$lib/comps/ui/forms';
+	import SimpleInput from '$lib/comps/ui/input/input.svelte'; // without form logic
+	import SimpleButton from '$lib/comps/ui/button/button.svelte'; // without form logic
+	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';
+	import * as Card from '$lib/comps/ui/card';
+	import Label from '$lib/comps/ui/label/label.svelte';
+
+	type Props = {
+		superform: SuperValidated<Infer<typeof update>>;
+	};
+	const { superform }: Props = $props();
+
+	const form = superForm(superform, {
+		validators: valibotClient(update),
+		dataType: 'json'
+	});
+	const { form: formData, enhance, message } = form;
+
+	function removeHeaderRow(row: number) {
+		if ($formData.settings) {
+			$formData.settings.website.header_links.splice(row, 1);
+			$formData.settings = $formData.settings;
+		}
+	}
+	function addHeaderRow() {
+		if ($formData.settings) {
+			$formData.settings.website.header_links.push({ text: '', url: '', new_tab: false });
+			$formData.settings = $formData.settings;
+		}
+	}
+
+	function removeFooterRow(row: number) {
+		if ($formData.settings) {
+			$formData.settings.website.footer_links.splice(row, 1);
+			$formData.settings = $formData.settings;
+		}
+	}
+	function addFooterRow() {
+		if ($formData.settings) {
+			$formData.settings.website.footer_links.push({ text: '', url: '', new_tab: false });
+			$formData.settings = $formData.settings;
+		}
+	}
+</script>
+
+<form method="post" use:enhance>
+	<Grid cols={1}>
+		<Error error={$message}></Error>
+		{#if $formData.settings}
+			<Input
+				name="settings.website.custom_domain"
+				label={$page.data.t.forms.fields.settings.website.custom_domain.label()}
+				description={$page.data.t.forms.fields.settings.website.custom_domain.description()}
+				{form}
+				bind:value={$formData.settings.website.custom_domain as string}
+			/>
+			<Input
+				name="settings.website.logo_url"
+				label={$page.data.t.forms.fields.settings.website.logo.label()}
+				description={$page.data.t.forms.fields.settings.website.logo.description()}
+				{form}
+				bind:value={$formData.settings.website.logo_url as string}
+			/>
+			<Input
+				name="settings.website.favicon"
+				label={$page.data.t.forms.fields.settings.website.favicon.label()}
+				description={$page.data.t.forms.fields.settings.website.favicon.description()}
+				{form}
+				bind:value={$formData.settings.website.favicon as string}
+			/>
+
+			<Card.Root class="mt-4">
+				<Card.Header>
+					<Card.Title>{$page.data.t.forms.fields.settings.website.header_links.title()}</Card.Title>
+					<p class="text-muted-foreground text-sm">
+						{$page.data.t.forms.fields.settings.website.header_links.description()}
+					</p>
+				</Card.Header>
+				<Card.Content>
+					{#each $formData.settings.website.header_links as link, i}
+						<div class="mb-4">{@render headerLinkRow(i)}</div>
+					{/each}
+					<div class="flex justify-end">
+						<SimpleButton variant="outline" size="sm" onclick={addHeaderRow}
+							>{$page.data.t.forms.fields.settings.website.add_link.label()}</SimpleButton
+						>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<Card.Root class="mt-4">
+				<Card.Header>
+					<Card.Title>{$page.data.t.forms.fields.settings.website.footer_links.title()}</Card.Title>
+					<p class="text-muted-foreground text-sm">
+						{$page.data.t.forms.fields.settings.website.footer_links.description()}
+					</p>
+				</Card.Header>
+				<Card.Content>
+					{#each $formData.settings.website.footer_links as link, i}
+						<div class="mb-4">{@render footerLinkRow(i)}</div>
+					{/each}
+					<div class="flex justify-end">
+						<SimpleButton variant="outline" size="sm" onclick={addFooterRow}
+							>{$page.data.t.forms.fields.settings.website.add_link.label()}</SimpleButton
+						>
+					</div>
+				</Card.Content>
+			</Card.Root>
+		{/if}
+
+		<Button type="submit" class="mt-3" />
+		<Debug data={$formData}></Debug>
+	</Grid>
+</form>
+
+{#snippet headerLinkRow(row: number)}
+	<Grid cols={3}>
+		{#if $formData.settings}
+			<div>
+				<Label>{$page.data.t.forms.fields.generic.name.label()}</Label>
+				<SimpleInput bind:value={$formData.settings.website.header_links[row].text} />
+			</div>
+			<div>
+				<Label>{$page.data.t.forms.fields.generic.url.label()}</Label>
+				<SimpleInput bind:value={$formData.settings.website.header_links[row].url} />
+			</div>
+			<div class="flex items-center gap-1 justify-between">
+				<div class="items-top flex space-x-2">
+					<Checkbox bind:checked={$formData.settings.website.header_links[row].new_tab} />
+					<div class="grid gap-1.5 leading-none">
+						<Label
+							for="terms1"
+							class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+						>
+							{$page.data.t.forms.fields.settings.website.open_in_new_tab.label()}
+						</Label>
+						<p class="text-muted-foreground text-sm">
+							{$page.data.t.forms.fields.settings.website.open_in_new_tab.description()}
+						</p>
+					</div>
+				</div>
+				<SimpleButton variant="destructive" size="sm" onclick={() => removeHeaderRow(row)}
+					>{$page.data.t.forms.buttons.remove()}</SimpleButton
+				>
+			</div>
+		{/if}
+	</Grid>
+{/snippet}
+
+{#snippet footerLinkRow(row: number)}
+	<Grid cols={3}>
+		{#if $formData.settings}
+			<div>
+				<Label>{$page.data.t.forms.fields.generic.name.label()}</Label>
+				<SimpleInput bind:value={$formData.settings.website.footer_links[row].text} />
+			</div>
+			<div>
+				<Label>{$page.data.t.forms.fields.generic.url.label()}</Label>
+				<SimpleInput bind:value={$formData.settings.website.footer_links[row].url} />
+			</div>
+			<div class="flex items-center gap-1 justify-between">
+				<div class="items-top flex space-x-2">
+					<Checkbox bind:checked={$formData.settings.website.footer_links[row].new_tab} />
+					<div class="grid gap-1.5 leading-none">
+						<Label
+							for="terms1"
+							class="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+						>
+							{$page.data.t.forms.fields.settings.website.open_in_new_tab.label()}
+						</Label>
+						<p class="text-muted-foreground text-sm">
+							{$page.data.t.forms.fields.settings.website.open_in_new_tab.description()}
+						</p>
+					</div>
+				</div>
+				<SimpleButton variant="destructive" size="sm" onclick={() => removeFooterRow(row)}
+					>{$page.data.t.forms.buttons.remove()}</SimpleButton
+				>
+			</div>
+		{/if}
+	</Grid>
+{/snippet}

--- a/src/routes/(app)/settings/website/WebsiteConfigForm.svelte
+++ b/src/routes/(app)/settings/website/WebsiteConfigForm.svelte
@@ -2,6 +2,7 @@
 	import { page } from '$app/stores';
 	import { update, type Settings } from '$lib/schema/core/instance';
 	import { type SuperValidated } from 'sveltekit-superforms';
+	import ImageUpload from '$lib/comps/ui/form/controls/file_upload/simple_image_upload.svelte';
 	import {
 		Button,
 		Error,
@@ -17,7 +18,6 @@
 	import Checkbox from '$lib/comps/ui/checkbox/checkbox.svelte';
 	import * as Card from '$lib/comps/ui/card';
 	import Label from '$lib/comps/ui/label/label.svelte';
-
 	type Props = {
 		superform: SuperValidated<Infer<typeof update>>;
 	};
@@ -60,25 +60,22 @@
 	<Grid cols={1}>
 		<Error error={$message}></Error>
 		{#if $formData.settings}
-			<Input
+			<!-- We don't yet support custom domains, but we we will include this setting here once support is added -->
+			<!-- <Input
 				name="settings.website.custom_domain"
 				label={$page.data.t.forms.fields.settings.website.custom_domain.label()}
 				description={$page.data.t.forms.fields.settings.website.custom_domain.description()}
 				{form}
 				bind:value={$formData.settings.website.custom_domain as string}
-			/>
-			<Input
-				name="settings.website.logo_url"
+			/> -->
+			<ImageUpload
+				bind:value={$formData.settings.website.logo_url as string}
 				label={$page.data.t.forms.fields.settings.website.logo.label()}
 				description={$page.data.t.forms.fields.settings.website.logo.description()}
-				{form}
-				bind:value={$formData.settings.website.logo_url as string}
 			/>
-			<Input
-				name="settings.website.favicon"
+			<ImageUpload
 				label={$page.data.t.forms.fields.settings.website.favicon.label()}
 				description={$page.data.t.forms.fields.settings.website.favicon.description()}
-				{form}
 				bind:value={$formData.settings.website.favicon as string}
 			/>
 


### PR DESCRIPTION
This pull request adds a section to edit website configuration settings to the `/settings/website` page. 

The main things are: updating the logo and favicon for website pages, which uses a newly created image upload component. One thing I've noticed in doing this is that we have duplication of some image/file upload components, so I have made a task to go back and review and rationalize them. 

The other aspect is editing header and footer menus. This is a fairly simple component which is just modifying a simple JSON array. 

This PR includes some tests for some of the text util functions that are used, as well as a new validation schema for domain names (which doesn't actually get used in this PR, but will be useful in the future). 