### PR TITLE
Feature/simple analytics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,3 +80,6 @@ DEFAULT_CREATE_TEST_DATA=true #If true, the app will create test data on startup
 #OPENAI
 OPENAI_API_KEY=
 
+#ANALYTICS (using https://umami.is/)
+UMAMI_API_KEY=
+PUBLIC_UMAMI_WEBSITE_ID=

--- a/src/app.html
+++ b/src/app.html
@@ -2,7 +2,6 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<script defer src="https://cloud.umami.is/script.js" data-website-id="5678fa17-8b31-4017-bcee-5c723cad11bc"></script>
 		<link href="%sveltekit.assets%/logos/logomark.svg"  rel="icon" media="(prefers-color-scheme: light)" >
 		<link href="%sveltekit.assets%/logos/white_logomark.svg"  rel="icon" media="(prefers-color-scheme: dark)">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/app.html
+++ b/src/app.html
@@ -2,6 +2,7 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
+		<script defer src="https://cloud.umami.is/script.js" data-website-id="5678fa17-8b31-4017-bcee-5c723cad11bc"></script>
 		<link href="%sveltekit.assets%/logos/logomark.svg"  rel="icon" media="(prefers-color-scheme: light)" >
 		<link href="%sveltekit.assets%/logos/white_logomark.svg"  rel="icon" media="(prefers-color-scheme: dark)">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -31,7 +31,6 @@ Sentry.init({
 export const handleError: HandleServerError = Sentry.handleErrorWithSentry();
 
 export async function handleFetch({ event, request, fetch }) {
-	log.info(`🍔 FETCH ${event.request.method} ${event.url.href}`);
 	return await fetch(request);
 }
 
@@ -78,7 +77,9 @@ const belcodaHandler: Handle = async ({ event, resolve }) => {
 		jsonResponse,
 		response: apiResponse
 	} = await buildAdminInstance({ event });
-	if (jsonResponse && apiResponse) return apiResponse;
+	if (jsonResponse && apiResponse) {
+		return apiResponse;
+	}
 	if (event.url.pathname.startsWith('/login')) {
 		if (authenticated) {
 			return new Response(null, {
@@ -102,7 +103,9 @@ const belcodaHandler: Handle = async ({ event, resolve }) => {
 			}
 		});
 	}
-
+	log.info(
+		`🔒 ${event.request.method}: (${event.url.href}) [${event.locals.instance.slug}/${event.locals.admin?.id}]`
+	);
 	const response = await resolve(returnEvent);
 	return response;
 };

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -1,0 +1,42 @@
+import { UMAMI_API_KEY } from '$env/static/private';
+import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
+import { type RequestEvent } from '@sveltejs/kit';
+import { pino } from '$lib/server';
+const log = pino('$lib/server/hooks/analytics/log');
+export default async function (event: RequestEvent): Promise<void> {
+	try {
+		const payload = {
+			hostname: event.url.hostname,
+			language: event.locals.language,
+			referrer: event.request.headers.get('referer'),
+			domain: event.url.hostname,
+			screen: 'N/A',
+			title: 'N/A',
+			url: event.url.href,
+			name: `${event.request.method}`,
+			website: PUBLIC_UMAMI_WEBSITE_ID,
+			data: {
+				team: event.locals.instance?.slug || 'UNKNOWN',
+				id: event.locals.admin?.id || 'UNKNOWN'
+			}
+		};
+		const headers = {
+			'Content-Type': 'application/json',
+			'x-umami-api-key': UMAMI_API_KEY,
+			'user-agent': event.request.headers.get('user-agent') || 'BelcodaFetch'
+		};
+		const response = await fetch('https://cloud.umami.is/api/send', {
+			method: 'POST',
+			headers,
+			body: JSON.stringify({
+				type: 'event',
+				payload
+			})
+		});
+		if (response.status !== 200) {
+			log.error(`Failed to log analytics event (${response.statusText}): ${await response.text()}`);
+		}
+	} catch (err) {
+		log.error(err);
+	}
+}

--- a/src/lib/server/hooks/build_locals.ts
+++ b/src/lib/server/hooks/build_locals.ts
@@ -12,11 +12,13 @@ export function buildLocalLanguage(event: RequestEvent): SL[number] {
 }
 
 const log = pino('$lib/server/hooks/build_locals');
+import logToAnalytics from '$lib/server/hooks/analytics/log';
 
 export async function buildAdminInstance({ event }: { event: RequestEvent }): Promise<{
 	authenticated: boolean;
 	event: RequestEvent;
-	jsonResponse: boolean;
+	//in this context, jsonResponse means building a Response in this function and returning it directly
+	jsonResponse: boolean; //only used for errors
 	response?: Response;
 }> {
 	if (event.url.pathname.startsWith('/api/v1')) {
@@ -25,6 +27,8 @@ export async function buildAdminInstance({ event }: { event: RequestEvent }): Pr
 			event.locals.admin = admin;
 			event.locals.instance = instance;
 			event.locals.language = instance.language;
+			//log the request to umami only on /api/v1 routes
+			await logToAnalytics(event);
 			return { authenticated: true, event, jsonResponse: false };
 		} catch (err) {
 			log.trace(err);
@@ -34,6 +38,8 @@ export async function buildAdminInstance({ event }: { event: RequestEvent }): Pr
 				event.locals.admin = admin;
 				event.locals.instance = instance;
 				event.locals.language = instance.language;
+				//log the request to umami only on /api/v1 routes
+				await logToAnalytics(event);
 				return { authenticated: true, event, jsonResponse: false };
 			} catch (err) {
 				log.error(err);

--- a/src/lib/server/hooks/handlers.ts
+++ b/src/lib/server/hooks/handlers.ts
@@ -20,27 +20,25 @@ export type HandlerResponse =
 	  };
 
 type Resolve = (event: RequestEvent, opts?: ResolveOptions | undefined) => MaybePromise<Response>;
-
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {
-	if (event.url.pathname.startsWith('/api/v1')) {
-		log.info(`✨ ${event.request.method} ${event.url.href}`);
-	} else {
-		log.info(`🌎 ${event.request.method} ${event.url.href}`);
-	}
 	if (event.url.pathname.startsWith('/webhooks/email')) {
+		log.info(`🌎 ${event.request.method} ${event.url.href}`);
 		return await emailHandler(event, resolve);
 	}
 	if (event.url.pathname.startsWith('/favicon.ico')) {
 		return { continue: false, response: new Response(null, { status: 204 }) };
 	}
 	if (event.url.pathname.startsWith('/webhooks/whatsapp')) {
+		log.info(`🌎 ${event.request.method} ${event.url.href}`);
 		return await whatsappHandler(event, resolve);
 	}
 
 	if (event.url.pathname.startsWith('/webhooks/whapi')) {
+		log.info(`🌎 ${event.request.method} ${event.url.href}`);
 		return await whapiHandler(event, resolve);
 	}
 
+	//conditional on it being a worker request
 	const workerResponse = await worker(event, resolve);
 	if (!workerResponse.continue) return { continue: false, response: workerResponse.response };
 
@@ -49,6 +47,7 @@ export default async function (event: RequestEvent, resolve: Resolve): Promise<H
 		if (subdomain) {
 			log.info(`🎣 Request subdomain is ${subdomain}`);
 			const response = await handlePageRender(event, subdomain);
+			log.info(`🌎 ${event.request.method} ${event.url.href}`);
 			return { continue: false, response: response };
 		}
 	}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -10,7 +10,7 @@
 		breadcrumbs as breadcrumbsConstructor,
 		renderBreadcrumb
 	} from '$lib/comps/nav/breadcrumbs/breadcrumbs';
-
+	import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
 	import * as Sentry from '@sentry/sveltekit';
 	import { browser } from '$app/environment';
 	if (browser) {
@@ -54,9 +54,21 @@
 		}
 		flash.set(undefined);
 	});
+	if (browser) {
+		if ('umami' in window) {
+			//@ts-expect-error
+			window.umami.identify({ team: $page.data.instance.slug, id: $page.data.admin.id });
+		}
+	}
 </script>
 
 <svelte:head>
+	<script
+		defer
+		src="https://cloud.umami.is/script.js"
+		data-website-id={PUBLIC_UMAMI_WEBSITE_ID}
+		data-tag={$page.data.instance.slug}
+	></script>
 	{#key $page.url.pathname}
 		<title>{pageTitle} - Belcoda</title>
 	{/key}

--- a/src/routes/(utility)/+layout.svelte
+++ b/src/routes/(utility)/+layout.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
 	import '../../app.css';
+	import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
 </script>
+
+<svelte:head>
+	<script
+		defer
+		src="https://cloud.umami.is/script.js"
+		data-website-id={PUBLIC_UMAMI_WEBSITE_ID}
+		data-tag="no_auth"
+	></script>
+</svelte:head>
 
 <section class="min-h-screen flex items-center justify-center">
 	<slot />

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,10 +14,15 @@ const config = {
 			mode: 'auto',
 			directives: {
 				'default-src': ['self'],
-				'connect-src': ['self', `*.sentry.io`],
+				'connect-src': ['self', '*.sentry.io', 'https://api-gateway.umami.dev/api/send'],
 				// for now we need to keep 'unsafe-inline' for a couple of bits-ui components that inject inline event handlers
 				// we also need it for our custom code options, which currently inject inline styles. We can
-				'script-src': ['self', 'https://accounts.google.com', 'unsafe-inline'],
+				'script-src': [
+					'self',
+					'https://accounts.google.com',
+					'unsafe-inline',
+					'https://cloud.umami.is'
+				],
 				'style-src': ['self', 'unsafe-inline'],
 				'worker-src': ['self', 'blob:'],
 				'img-src': [


### PR DESCRIPTION
This adds https://umami.is, a basic, lightweight, privacy preserving analytics solution to Belcoda, which will help us keep track of usage on our platform. 

This is especially important as we move to onboard more users and try out different onboarding processes. 

There are two main aspects to this: 

1. Adding client-side event tracking, which is basically a script tag
2. Server-side tracking using the API. Right now I've set it up so that every single API route gets triggered, just to get a good baseline of data. But eventually, we will shift it to be on specific events (eg: importing people, creating a new event, etc) 

As part of implementing this, I moved some of the per-request logging to different for authenticated routes, which required shifting where the logging happens a bit. 

Also note that adding umami required the creation of two new env vars, so this includes updates to the example .env file. 
