### PR TITLE
Fix a regression in subdomain handling logic (including test case)

### DIFF
--- a/src/lib/server/hooks/handlers.test.ts
+++ b/src/lib/server/hooks/handlers.test.ts
@@ -21,6 +21,10 @@ describe('detectSubdomain', () => {
 		expect(detectSubdomain('sub.example.com', 'example.com')).toBe('sub');
 	});
 
+	it('should return the correct subdomain when the host is localhost', () => {
+		expect(detectSubdomain('sub.localhost:5173', 'localhost:5173')).toBe('sub');
+	});
+
 	it('should return the subdomain even if the root domain is a multi-part ccTLD/compound ccTLD', () => {
 		expect(detectSubdomain('sub.example.com.au', 'example.com.au')).toBe('sub');
 	});

--- a/src/lib/server/hooks/handlers.ts
+++ b/src/lib/server/hooks/handlers.ts
@@ -61,10 +61,15 @@ export function detectSubdomain(host: string, rootDomain: string): string | fals
 		return false;
 	}
 
-	// this will break for domains like .com.au or .co.uk or .co.jp, but they should be handled by the root domain above
 	const parts = host.split('.');
+	// if it's a single-part domain (eg: example.com), then domain.split('.').length === 2 means it's root
 	if (parts.length < 3) {
-		return false;
+		// note that this will false-negative for domains like .com.au or .co.uk or .co.jp, but they should all be covered by the root check domain above
+
+		if (parts[parts.length - 1].includes('localhost') === false) {
+			//subdomain.localhost:5173 is a valid subdomain but has less than 3 parts when split by '.'
+			return false;
+		}
 	}
 
 	if (DISALLOWED_NAMES_SET.has(parts[0])) {


### PR DESCRIPTION
Recent changes to subdomain handling introduced a bug for localhost development environment (because they expected the root domain to have a `.`). It never impacted production, only development environments at localhost. I've fixed this bug and added a test case.