### PR TITLE
Stop redis connecting during test running

### DIFF
--- a/src/lib/server/utils/redis.ts
+++ b/src/lib/server/utils/redis.ts
@@ -16,7 +16,11 @@ client.on('error', (err) => log.error('Redis Client Error', err));
 client.on('connect', () => log.info(`Redis client connected at ${REDIS_URL}`));
 client.on('ready', () => log.info(`Redis client ready at ${REDIS_URL}`));
 
-if (!building && process.env.CI !== 'true') {
+if (
+	!building && //this causes build errors
+	process.env.CI !== 'true' && //this pollutes the logs with connection errors and can cause parse errors in our JUnit output
+	process.env.MODE !== 'test' //pollutes the logs with connection info and can cause issues
+) {
 	await client.connect();
 }
 function safe_stringify(value: any) {


### PR DESCRIPTION
In the future, we might need Redis to connect (or to mock our Redis) but for now it is causing potential log pollution and isn't needed so I'm removing it from running during tests