### PR TITLE
Feature/email preview autogen

### DIFF
--- a/src/lib/comps/forms/EditEmailMessageForm.svelte
+++ b/src/lib/comps/forms/EditEmailMessageForm.svelte
@@ -48,6 +48,13 @@
 	import { Input, HTML, Checkbox, Button, Textarea, Grid, Switch } from '$lib/comps/ui/forms';
 	import * as Select from '$lib/comps/ui/select';
 	import * as Card from '$lib/comps/ui/card';
+	import Label from '$lib/comps/ui/label/label.svelte';
+	import SwitchWidget from '$lib/comps/ui/switch/switch.svelte';
+	import * as Alert from '$lib/comps/ui/alert/index.js';
+	import TriangleAlert from 'lucide-svelte/icons/triangle-alert';
+	import ChevronsUpDown from 'lucide-svelte/icons/chevrons-up-down';
+	import * as Collapsible from '$lib/comps/ui/collapsible/index.js';
+	import { buttonVariants } from '$lib/comps/ui/button/index.js';
 
 	let editHTML = true;
 	$: templatesForSelect = templates.map((template) => ({
@@ -107,36 +114,12 @@
 	<Input
 		{disabled}
 		{form}
-		name={replyTo}
-		label={$page.data.t.forms.fields.email.reply_to.label()}
-		bind:value={$replyToValue as string}
-	/>
-	<Input
-		{disabled}
-		{form}
 		name={subject}
 		label={$page.data.t.forms.fields.email.subject.label()}
 		bind:value={$subjectValue as string}
 	/>
 
-	<Textarea
-		{disabled}
-		{form}
-		name={previewText}
-		label={$page.data.t.forms.fields.email.preview_text.label()}
-		description={$page.data.t.forms.fields.email.preview_text.description()}
-		bind:value={$previewTextValue as string}
-	/>
-
-	<!-- Right now, we don't need this, and it will be confusing for users
-  <Checkbox
-		{form}
-		name={`${formKey}.useHtmlAsText`}
-		label={$page.data.t.forms.fields.email.useHtmlAsPlainText.label()}
-		description={$page.data.t.forms.fields.email.useHtmlAsPlainText.description()}
-		bind:checked={$formData[formKey].useHtmlAsText}
-	/> -->
-	<!-- {#if $useHtmlAsTextValue}
+	{#if !$useHtmlAsTextValue}
 		<div class="flex justify-end items-center gap-2">
 			<Label class="text-muted-foreground"
 				>{editHTML
@@ -145,9 +128,7 @@
 			>
 			<SwitchWidget disabled={$useHtmlAsTextValue} bind:checked={editHTML} />
 		</div>
-	{/if} -->
-	<Separator class="my-6" />
-	{@render templateChange()}
+	{/if}
 	{#if editHTML}
 		<div class="relative">
 			{#if disabled}<div class="bg-white opacity-70 absolute z-20 inset-0"></div>{/if}
@@ -161,10 +142,82 @@
 			rows={16}
 			label={null}
 			bind:value={$textValue as string}
-		/>
-	{/if}
+		/>{/if}
 </Grid>
 
+<!-- Advanced settings -->
+<Collapsible.Root class="w-full space-y-2">
+	<div class="flex items-center justify-between space-x-4 px-4">
+		<h4 class="text-sm font-semibold">{$page.data.t.forms.buttons.advanced_settings()}</h4>
+		<Collapsible.Trigger class={buttonVariants({ variant: 'ghost', size: 'sm', class: 'w-9 p-0' })}>
+			<ChevronsUpDown />
+			<span class="sr-only">{$page.data.t.forms.buttons.toggle()}</span>
+		</Collapsible.Trigger>
+	</div>
+	<Collapsible.Content class="space-y-2">
+		<Alert.Root>
+			<TriangleAlert class="size-4" />
+			<Alert.Title>{$page.data.t.common.alerts.heads_up()}</Alert.Title>
+			<Alert.Description class="text-muted-foreground mt-2">
+				{$page.data.t.forms.fields.email.advanced_settings.warning()}
+			</Alert.Description>
+		</Alert.Root>
+		<Grid cols={1}>
+			{#if templates.length > 0}
+				<div class="w-full">
+					<Label>{$page.data.t.forms.fields.email.template.label()}</Label>
+					<Select.Root
+						type="single"
+						onValueChange={(val) => {
+							const id = Number(val);
+							$templateIdValue = id;
+						}}
+					>
+						<Select.Trigger class="w-full">
+							{templates.find((t) => t.id === $templateIdValue)?.name ||
+								$page.data.t.forms.fields.email.template.label()}
+						</Select.Trigger>
+						<Select.Content>
+							{#each templates as template}
+								<Select.Item value={template.id.toString()}>{template.name}</Select.Item>
+							{/each}
+						</Select.Content>
+					</Select.Root>
+					<div class="text-muted-foreground text-sm mt-1.5">
+						{$page.data.t.forms.fields.email.template.description()}
+					</div>
+				</div>
+			{/if}
+
+			<Input
+				{disabled}
+				{form}
+				name={replyTo}
+				label={$page.data.t.forms.fields.email.reply_to.label()}
+				description={$page.data.t.forms.fields.email.reply_to.description()}
+				bind:value={$replyToValue as string}
+			/>
+
+			<Textarea
+				{disabled}
+				{form}
+				name={previewText}
+				label={$page.data.t.forms.fields.email.preview_text.label()}
+				description={$page.data.t.forms.fields.email.preview_text.description()}
+				bind:value={$previewTextValue as string}
+			/>
+			<Checkbox
+				{form}
+				name={useHtmlAsText}
+				label={$page.data.t.forms.fields.email.useHtmlAsPlainText.label()}
+				description={$page.data.t.forms.fields.email.useHtmlAsPlainText.description()}
+				bind:checked={$useHtmlAsTextValue as boolean}
+			/>
+		</Grid>
+	</Collapsible.Content>
+</Collapsible.Root>
+
+<!-- Test email -->
 {#if allowTestEmail && !disabled}
 	<Separator class="my-6" />
 	<Card.Root class="mb-6">
@@ -184,27 +237,3 @@
 		</Card.Footer>
 	</Card.Root>
 {/if}
-
-{#snippet templateChange()}
-	{#if templates.length > 0}
-		<div class="flex justify-end">
-			<Select.Root
-				type="single"
-				onValueChange={(val) => {
-					const id = Number(val);
-					$templateIdValue = id;
-				}}
-			>
-				<Select.Trigger class="w-[480px]">
-					{templates.find((t) => t.id === $templateIdValue)?.name ||
-						$page.data.t.forms.fields.email.template.label()}
-				</Select.Trigger>
-				<Select.Content>
-					{#each templates as template}
-						<Select.Item value={template.id.toString()}>{template.name}</Select.Item>
-					{/each}
-				</Select.Content>
-			</Select.Root>
-		</div>
-	{/if}
-{/snippet}

--- a/src/lib/comps/forms/EditEmailMessageForm.svelte
+++ b/src/lib/comps/forms/EditEmailMessageForm.svelte
@@ -104,13 +104,7 @@
 			bind:value={$nameValue as string}
 		/>
 	{/if}
-	<Input
-		{disabled}
-		{form}
-		name={from}
-		label={$page.data.t.forms.fields.email.from.label()}
-		bind:value={$fromValue as string}
-	/>
+
 	<Input
 		{disabled}
 		{form}
@@ -163,31 +157,14 @@
 			</Alert.Description>
 		</Alert.Root>
 		<Grid cols={1}>
-			{#if templates.length > 0}
-				<div class="w-full">
-					<Label>{$page.data.t.forms.fields.email.template.label()}</Label>
-					<Select.Root
-						type="single"
-						onValueChange={(val) => {
-							const id = Number(val);
-							$templateIdValue = id;
-						}}
-					>
-						<Select.Trigger class="w-full">
-							{templates.find((t) => t.id === $templateIdValue)?.name ||
-								$page.data.t.forms.fields.email.template.label()}
-						</Select.Trigger>
-						<Select.Content>
-							{#each templates as template}
-								<Select.Item value={template.id.toString()}>{template.name}</Select.Item>
-							{/each}
-						</Select.Content>
-					</Select.Root>
-					<div class="text-muted-foreground text-sm mt-1.5">
-						{$page.data.t.forms.fields.email.template.description()}
-					</div>
-				</div>
-			{/if}
+			<Input
+				{disabled}
+				{form}
+				name={from}
+				label={$page.data.t.forms.fields.email.from.label()}
+				description={$page.data.t.forms.fields.email.from.description()}
+				bind:value={$fromValue as string}
+			/>
 
 			<Input
 				{disabled}
@@ -206,6 +183,9 @@
 				description={$page.data.t.forms.fields.email.preview_text.description()}
 				bind:value={$previewTextValue as string}
 			/>
+
+			{@render templateSelector()}
+
 			<Checkbox
 				{form}
 				name={useHtmlAsText}
@@ -237,3 +217,31 @@
 		</Card.Footer>
 	</Card.Root>
 {/if}
+
+{#snippet templateSelector()}
+	{#if templates.length > 0}
+		<div class="w-full mb-2">
+			<Label>{$page.data.t.forms.fields.email.template.label()}</Label>
+			<Select.Root
+				type="single"
+				onValueChange={(val) => {
+					const id = Number(val);
+					$templateIdValue = id;
+				}}
+			>
+				<Select.Trigger class="w-full">
+					{templates.find((t) => t.id === $templateIdValue)?.name ||
+						$page.data.t.forms.fields.email.template.label()}
+				</Select.Trigger>
+				<Select.Content>
+					{#each templates as template}
+						<Select.Item value={template.id.toString()}>{template.name}</Select.Item>
+					{/each}
+				</Select.Content>
+			</Select.Root>
+			<div class="text-muted-foreground text-sm mt-1.5">
+				{$page.data.t.forms.fields.email.template.description()}
+			</div>
+		</div>
+	{/if}
+{/snippet}

--- a/src/lib/i18n/localizations/common.ts
+++ b/src/lib/i18n/localizations/common.ts
@@ -341,6 +341,18 @@ export default function (locale: SL) {
 			}
 		},
 		alerts: {
+			heads_up: () => {
+				return t(locale, {
+					en: 'Heads up',
+					ja: 'お知らせ',
+					pt: 'Atenção',
+					es: 'Atención',
+					fr: 'Attention',
+					sw: 'Kumbuka',
+					th: 'เตือน',
+					zh: '注意'
+				});
+			},
 			send_email: () => {
 				return t(locale, {
 					en: 'Are you sure? Pres OK to send the email.',

--- a/src/lib/i18n/localizations/forms.ts
+++ b/src/lib/i18n/localizations/forms.ts
@@ -896,6 +896,32 @@ export default function (locale: SL) {
 							th: 'ตอบกลับไปที่',
 							zh: '回复'
 						});
+					},
+					description: () => {
+						return t(locale, {
+							en: `The address that replies to this email will be sent to. If you change it, you will not automatically receive replies inside Belcoda.`,
+							ja: `このメールに返信するアドレスが送信されます。変更すると、Belcoda内で自動的に返信を受け取ることはできません。`,
+							pt: `O endereço para o qual as respostas a este email serão enviadas. Se você alterá-lo, não receberá automaticamente respostas dentro do Belcoda.`,
+							es: `La dirección a la que se enviarán las respuestas a este correo electrónico. Si lo cambia, no recibirá automáticamente respuestas dentro de Belcoda.`,
+							fr: `L'adresse à laquelle les réponses à cet e-mail seront envoyées. Si vous la modifiez, vous ne recevrez pas automatiquement de réponses à l'intérieur de Belcoda.`,
+							sw: `Anwani ambayo majibu kwa barua pepe hii yatapelekwa. Ikiwa utaibadilisha, hutapokea majibu kiotomatiki ndani ya Belcoda.`,
+							th: `ที่อยู่ที่จะส่งกลับไปยังอีเมลนี้ หากคุณเปลี่ยนมันคุณจะไม่ได้รับการตอบกลับอัตโนมัติภายใน Belcoda`,
+							zh: `将回复此电子邮件的地址发送到。如果您更改它，您将无法在Belcoda内自动接收回复。`
+						});
+					}
+				},
+				advanced_settings: {
+					warning: () => {
+						return t(locale, {
+							en: `You might not need to change these settings. The default settings are correct for the majority of cases, and making changes can break automatic handling of email replies and other features. Please read the documentation fully before making changes.`,
+							ja: `これらの設定を変更する必要がない場合があります。デフォルト設定はほとんどの場合に適しており、変更すると電子メールの返信の自動処理やその他の機能が壊れる可能性があります。変更する前に文書を十分に読んでください。`,
+							pt: `Você pode não precisar alterar essas configurações. As configurações padrão são corretas para a maioria dos casos e fazer alterações pode quebrar o tratamento automático de respostas de e-mail e outras funcionalidades. Por favor, leia a documentação completamente antes de fazer alterações.`,
+							es: `Es posible que no necesite cambiar estas configuraciones. Las configuraciones predeterminadas son correctas para la mayoría de los casos y hacer cambios puede romper el manejo automático de respuestas de correo electrónico y otras funciones. Por favor, lea completamente la documentación antes de hacer cambios.`,
+							fr: `Vous pourriez ne pas avoir besoin de modifier ces paramètres. Les paramètres par défaut sont corrects pour la plupart des cas, et apporter des modifications peut rompre le traitement automatique des réponses aux e-mails et d'autres fonctionnalités. Veuillez lire la documentation entièrement avant de faire des modifications.`,
+							sw: `Huenda usihitaji kubadilisha mipangilio hii. Mipangilio ya msingi ni sahihi kwa kesi nyingi, na kufanya mabadiliko kunaweza kuvunja kushughulikia kiotomatiki cha majibu ya barua pepe na vipengele vingine. Tafadhali soma nyaraka kabisa kabla ya kufanya mabadiliko.`,
+							th: `คุณอาจจะไม่จำเป็นต้องเปลี่ยนการตั้งค่าเหล่านี้ การตั้งค่าเริ่มต้นถูกต้องสำหรับกรณีส่วนใหญ่และการเปลี่ยนแปลงอาจทำให้การจัดการอัตโนมัติของการตอบกลับอีเมลและคุณลักษณะอื่น ๆ เสีย โปรดอ่านเอกสารอย่างเต็มที่ก่อนที่จะทำการเปลี่ยนแปลง`,
+							zh: `您可能不需要更改这些设置。默认设置适用于大多数情况，进行更改可能会破坏电子邮件回复的自动处理和其他功能。请在进行更改之前完全阅读文档。`
+						});
 					}
 				},
 				preview_text: {
@@ -913,14 +939,14 @@ export default function (locale: SL) {
 					},
 					description: () => {
 						return t(locale, {
-							en: 'This is the text that appears in the email client preview',
-							ja: 'これはメールクライアントのプレビューに表示されるテキストです',
-							pt: 'Este é o texto que aparece na pré-visualização do cliente de email',
-							es: 'Este es el texto que aparece en la vista previa del cliente de correo electrónico',
-							fr: "C'est le texte qui apparaît dans l'aperçu du client de messagerie",
-							sw: 'Hii ndio maandishi yanayoonekana kwenye hakiki ya mteja wa barua pepe',
-							th: 'นี่คือข้อความที่ปรากฏในการตัวอย่างของไคลเอนต์อีเมล',
-							zh: '这是出现在电子邮件客户端预览中的文本'
+							en: `This is the text that appears in the email client preview. If you don't make changes to this text, a preview will be automatically generated based on the email subject and body.`,
+							ja: `これは電子メールクライアントのプレビューに表示されるテキストです。このテキストを変更しない場合、プレビューは電子メールの件名と本文に基づいて自動的に生成されます。`,
+							pt: `Este é o texto que aparece na pré-visualização do cliente de email. Se você não fizer alterações neste texto, uma pré-visualização será gerada automaticamente com base no assunto e no corpo do email.`,
+							es: `Este es el texto que aparece en la vista previa del cliente de correo electrónico. Si no realiza cambios en este texto, se generará automáticamente una vista previa basada en el asunto y el cuerpo del correo electrónico.`,
+							fr: `C'est le texte qui apparaît dans l'aperçu du client de messagerie. Si vous ne modifiez pas ce texte, un aperçu sera automatiquement généré en fonction de l'objet et du corps du message.`,
+							sw: `Hii ni maandishi yanayoonekana kwenye hakiki ya mteja wa barua pepe. Ikiwa hautafanya mabadiliko kwenye maandishi haya, hakiki itazalishwa kiotomatiki kulingana na somo la barua pepe na mwili.`,
+							th: `นี่คือข้อความที่ปรากฏในการตัวอย่างของไคลเอนต์อีเมล หากคุณไม่ทำการเปลี่ยนแปลงข้อความนี้ จะมีการสร้างการตัวอย่างโดยอัตโนมัติขึ้นจากเรื่องและเนื้อหาของอีเมล`,
+							zh: `这是出现在电子邮件客户端预览中的文本。如果您不对此文本进行更改，将根据电子邮件主题和正文自动生成预览。`
 						});
 					}
 				},
@@ -979,14 +1005,14 @@ export default function (locale: SL) {
 					},
 					description: () => {
 						return t(locale, {
-							en: 'Select a template to use for the email',
-							ja: 'メールに使用するテンプレートを選択',
-							pt: 'Selecione um modelo para usar no email',
-							es: 'Seleccione una plantilla para usar en el correo electrónico',
-							fr: "Sélectionnez un modèle à utiliser pour l'e-mail",
-							sw: 'Chagua kiolezo cha kutumia kwa barua pepe',
-							th: 'เลือกเทมเพลตที่จะใช้สำหรับอีเมล',
-							zh: '选择要用于电子邮件的模板'
+							en: 'Select a template to use for the email. Templates can be managed in the "Email Templates" section.',
+							ja: 'メールに使用するテンプレートを選択。 テンプレートは「メールテンプレート」セクションで管理できます。',
+							pt: 'Selecione um modelo para usar no email. Os modelos podem ser gerenciados na seção "Modelos de Email".',
+							es: 'Seleccione una plantilla para usar en el correo electrónico. Las plantillas se pueden gestionar en la sección "Plantillas de Correo Electrónico".',
+							fr: "Sélectionnez un modèle à utiliser pour l'e-mail. Les modèles peuvent être gérés dans la section «Modèles d'e-mail».",
+							sw: 'Chagua kiolezo cha kutumia kwa barua pepe. Violezo vinaweza kusimamiwa katika sehemu ya "Violezo vya Barua pepe".',
+							th: 'เลือกเทมเพลตที่จะใช้สำหรับอีเมล เทมเพลตสามารถจัดการได้ในส่วน "เทมเพลตอีเมล"',
+							zh: '选择要用于电子邮件的模板。 模板可以在“电子邮件模板”部分中管理。'
 						});
 					}
 				},
@@ -2443,6 +2469,18 @@ export default function (locale: SL) {
 			remove: () => {
 				return t(locale, {
 					en: 'Remove'
+				});
+			},
+			toggle: () => {
+				return t(locale, {
+					en: 'Toggle',
+					ja: 'トグル',
+					pt: 'Alternar',
+					es: 'Alternar',
+					fr: 'Basculer',
+					sw: 'Badilisha',
+					th: 'สลับ',
+					zh: '切换'
 				});
 			},
 			create: () => {

--- a/src/lib/schema/utils/openai.ts
+++ b/src/lib/schema/utils/openai.ts
@@ -15,10 +15,16 @@ export const htmlMetatagsOptions = {
 		contentTypeId: id
 	})
 };
+
+export const emailPreviewOptions = v.object({
+	emailMessageId: id
+});
+export type EmailPreviewOptions = v.InferOutput<typeof emailPreviewOptions>;
 export const emailPreview = v.object({
 	preview: longStringNotEmpty
 });
 export type EmailPreview = v.InferOutput<typeof emailPreview>;
+
 export type EventHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.event>;
 export type PetitionHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.petition>;
 export type ContentHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.content>;

--- a/src/lib/schema/utils/openai.ts
+++ b/src/lib/schema/utils/openai.ts
@@ -1,4 +1,4 @@
-import { v, id } from '$lib/schema/valibot';
+import { v, id, longStringNotEmpty } from '$lib/schema/valibot';
 
 export const htmlMetatagsOptions = {
 	event: v.object({
@@ -15,6 +15,10 @@ export const htmlMetatagsOptions = {
 		contentTypeId: id
 	})
 };
+export const emailPreview = v.object({
+	preview: longStringNotEmpty
+});
+export type EmailPreview = v.InferOutput<typeof emailPreview>;
 export type EventHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.event>;
 export type PetitionHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.petition>;
 export type ContentHTMLMetaTags = v.InferOutput<typeof htmlMetatagsOptions.content>;

--- a/src/lib/server/api/communications/email/messages.ts
+++ b/src/lib/server/api/communications/email/messages.ts
@@ -1,10 +1,11 @@
 import { db, pool, redis, filterQuery, BelcodaError } from '$lib/server';
 import * as schema from '$lib/schema/communications/email/messages';
 import { parse } from '$lib/schema/valibot';
-
+import { type EmailPreviewOptions } from '$lib/schema/utils/openai';
 function redisString(instanceId: number, messageId: number | 'all') {
 	return `i:${instanceId}:email_messages:${messageId}`;
 }
+import { read as readTemplate } from '$lib/server/api/communications/email/templates';
 
 export async function exists({
 	instanceId,
@@ -36,11 +37,15 @@ export async function exists({
 export async function create({
 	instanceId,
 	defaultTemplateId,
-	body
+	body,
+	queue,
+	t
 }: {
 	instanceId: number;
 	defaultTemplateId: number;
 	body: schema.Create;
+	queue: App.Queue;
+	t: App.Localization;
 }): Promise<schema.Read> {
 	const parsed = parse(schema.create, body);
 	const toInsert = {
@@ -48,10 +53,21 @@ export async function create({
 		template_id: parsed.template_id || defaultTemplateId,
 		...parsed
 	};
+
 	const inserted = await db.insert('communications.email_messages', toInsert).run(pool);
 	const parsedInserted = parse(schema.read, inserted);
 	await redis.del(redisString(instanceId, 'all'));
 	await redis.set(redisString(instanceId, parsedInserted.id), parsedInserted);
+
+	// if the preview text is the same as the template preview text, then we know we are safe to autogenerate the preview
+	const template = await readTemplate({ instanceId, templateId: toInsert.template_id, t: t });
+	if (parsedInserted.preview_text === template.preview_text) {
+		// but, on the contrary, if the preview text is different, that means it was manually set and we should not autogenerate the preview
+		const sendToQueue: EmailPreviewOptions = {
+			emailMessageId: parsedInserted.id
+		};
+		await queue('/utils/openai/generate_email_preview', instanceId, sendToQueue);
+	}
 	return parsedInserted;
 }
 
@@ -59,17 +75,24 @@ export async function update({
 	instanceId,
 	messageId,
 	body,
-	t
+	t,
+	queue
 }: {
 	instanceId: number;
 	messageId: number;
 	body: schema.Update;
 	t: App.Localization;
+	queue: App.Queue;
 }): Promise<schema.Read> {
 	const parsed = parse(schema.update, body);
 	const toUpdate = {
 		...parsed
 	};
+
+	// if the preview text is the same as before, we should autogenerate the preview because it was not manually set
+	const messageBeforeUpdate = await read({ instanceId, messageId, t });
+	const autogeneratePreview = messageBeforeUpdate.preview_text === parsed.preview_text;
+
 	const updated = await db
 		.update('communications.email_messages', toUpdate, { id: messageId, instance_id: instanceId })
 		.run(pool);
@@ -83,6 +106,12 @@ export async function update({
 	const parsedUpdated = parse(schema.read, updated[0]);
 	await redis.del(redisString(instanceId, 'all'));
 	await redis.set(redisString(instanceId, parsedUpdated.id), parsedUpdated);
+	if (autogeneratePreview) {
+		const sendToQueue: EmailPreviewOptions = {
+			emailMessageId: parsedUpdated.id
+		};
+		await queue('/utils/openai/generate_email_preview', instanceId, sendToQueue);
+	}
 	return parsedUpdated;
 }
 

--- a/src/lib/server/api/communications/email/messages.ts
+++ b/src/lib/server/api/communications/email/messages.ts
@@ -90,6 +90,14 @@ export async function update({
 	};
 
 	// if the preview text is the same as before, we should autogenerate the preview because it was not manually set
+	/*
+	NOTE: This current implementation is imperfect.
+	If a user provides a manually created preview, saves it, then makes additional changes to the email and saves those changes again --
+	the system will trigger an automatic generation of new preview text which will overwrite their manually created one. 
+	I'm pretty sure avoiding this outcome would require a database migration to add a new flag for the communications.email_messages table. 
+	Given that this is a very low priority feature and custom preview text is very unlikely to be a priority for any of our users in the foreseeable future, 
+	I'm happy leaving it as is and coming back to it later.
+	*/
 	const messageBeforeUpdate = await read({ instanceId, messageId, t });
 	const autogeneratePreview = messageBeforeUpdate.preview_text === parsed.preview_text;
 

--- a/src/lib/server/api/communications/email/sends.ts
+++ b/src/lib/server/api/communications/email/sends.ts
@@ -14,13 +14,15 @@ export async function create({
 	body,
 	defaultTemplateId,
 	t,
-	adminId
+	adminId,
+	queue
 }: {
 	instanceId: number;
 	body: schema.Create;
 	defaultTemplateId: number;
 	adminId: number;
 	t: App.Localization;
+	queue: App.Queue;
 }): Promise<schema.Read> {
 	const parsed = parse(schema.create, body);
 	const template = await readTemplate({ instanceId, templateId: defaultTemplateId, t });
@@ -36,7 +38,13 @@ export async function create({
 		point_person_id: adminId,
 		use_html_for_plaintext: true
 	};
-	const message = await createMessage({ instanceId, defaultTemplateId, body: messageBody });
+	const message = await createMessage({
+		instanceId,
+		defaultTemplateId,
+		body: messageBody,
+		queue: queue,
+		t
+	});
 	const toInsert = {
 		instance_id: instanceId,
 		message_id: message.id,

--- a/src/lib/server/api/events/events.ts
+++ b/src/lib/server/api/events/events.ts
@@ -69,7 +69,8 @@ export async function create({
 			instanceId,
 			defaultEmailTemplateId,
 			type: 'followup',
-			body: parsed
+			body: parsed,
+			queue
 		}),
 		registration_email: await createEventEmailNotification({
 			instance,
@@ -77,7 +78,8 @@ export async function create({
 			instanceId,
 			defaultEmailTemplateId,
 			type: 'registration',
-			body: parsed
+			body: parsed,
+			queue
 		}),
 		reminder_email: await createEventEmailNotification({
 			instance,
@@ -85,7 +87,8 @@ export async function create({
 			instanceId,
 			defaultEmailTemplateId,
 			type: 'reminder',
-			body: parsed
+			body: parsed,
+			queue
 		}),
 		cancellation_email: await createEventEmailNotification({
 			instance,
@@ -93,7 +96,8 @@ export async function create({
 			instanceId,
 			defaultEmailTemplateId,
 			type: 'cancellation',
-			body: parsed
+			body: parsed,
+			queue
 		}),
 		template_id: parsed.template_id || defaultTemplateId,
 		point_person_id: parsed.point_person_id || adminId,
@@ -381,7 +385,8 @@ async function createEventEmailNotification({
 	instanceId,
 	adminId,
 	instance,
-	defaultEmailTemplateId
+	defaultEmailTemplateId,
+	queue
 }: {
 	type: 'registration' | 'reminder' | 'cancellation' | 'followup';
 	body: schema.Create;
@@ -389,6 +394,7 @@ async function createEventEmailNotification({
 	adminId: number;
 	instance: ReadInstance;
 	defaultEmailTemplateId: number;
+	queue: App.Queue;
 }): Promise<number> {
 	const { htmlEmail, textEmail } = returnHtmlTextEmails(type);
 	const registrationEmail = await createEmailMessage({
@@ -405,6 +411,7 @@ async function createEventEmailNotification({
 			use_html_for_plaintext: true,
 			template_id: defaultEmailTemplateId
 		},
+		queue: queue,
 		defaultTemplateId: defaultEmailTemplateId
 	});
 	return registrationEmail.id;

--- a/src/lib/server/api/petitions/petitions.ts
+++ b/src/lib/server/api/petitions/petitions.ts
@@ -59,6 +59,7 @@ export async function create({
 	const instance = await readInstance({ instance_id: instanceId });
 	const emailMessage = await createPetitionEmail({
 		body: parsed,
+		queue,
 		instanceId,
 		adminId,
 		instance,
@@ -277,16 +278,19 @@ async function createPetitionEmail({
 	instanceId,
 	adminId,
 	instance,
-	defaultEmailTemplateId
+	defaultEmailTemplateId,
+	queue
 }: {
 	body: schema.Create;
 	instanceId: number;
 	adminId: number;
 	instance: ReadInstance;
 	defaultEmailTemplateId: number;
+	queue: App.Queue;
 }): Promise<number> {
 	const registrationEmail = await createEmailMessage({
 		instanceId,
+		queue,
 		body: {
 			name: randomUUID(),
 			point_person_id: adminId,

--- a/src/lib/server/utils/openai/schemas/emailPreview.ts
+++ b/src/lib/server/utils/openai/schemas/emailPreview.ts
@@ -1,0 +1,39 @@
+import { parse } from '$lib/schema/valibot';
+import { type EmailPreview, emailPreview } from '$lib/schema/utils/openai';
+
+import { jsonCompletion } from '$lib/server/utils/openai/index';
+export const SYSTEM_PROMPT: string = `You are responsible for generating the email preview text for an email. 
+
+Preview text is the bit of text below or next to an email’s subject line in the inbox that gives extra insight into what’s inside the email. Gmail refers to this as "snippets", Apple Mail refers to it as a "preview", and Outlook calls it a "Message Preview". Its purpose is to summarise the email content in an engaging manner that is likely to make the recipient want to open and read the email (but don't go for clickbait!). It should be approximately 90 characters long, and certainly no more than 210 characters.
+
+It must reflect the email's subject and body content. The body content will be presented in email HTML format, so it may be somewhat difficult to parse. Ignore the many table tags, and focus on the text content (but do pay attention to H1 and other tags that might denote information heirarchy). Keep in mind that it will be displayed next to the subject line, so try to make sure it makes sense and matches that thematically and in terms of content (without simply repeating or restating the subject line).
+
+If the email topic is political or sensitive, you can follow accordingly, but please do so with care. Do not write anything offensive or problematic, and definitely don't use any curse words or strong language! Please match the language of the content (ie: if the web page is in French, the metatag content you generate should accordingly be in French too)`;
+
+// JSON Schema for generating email previews. Currently OpenAI supports a limited subset of Json schema 7 so we can't generate it from the Valibot types. I'm sure this will happen in time.
+export const JSON_SCHEMA_EMAIL_PREVIEW = {
+	name: 'emailPreview',
+	strict: true,
+	schema: {
+		properties: {
+			preview: {
+				type: ['string']
+			}
+		},
+		additionalProperties: false,
+		required: ['preview'],
+		type: 'object'
+	}
+};
+
+export async function generateEmailPreview(
+	subject: string,
+	messsageHTML: string
+): Promise<EmailPreview> {
+	const prompt = `Subject: ${subject} 
+Body (email HTML): 
+${messsageHTML}`;
+	const result = await jsonCompletion(SYSTEM_PROMPT, prompt, JSON_SCHEMA_EMAIL_PREVIEW);
+	const parsed = parse(emailPreview, result.parsed);
+	return parsed;
+}

--- a/src/routes/(api)/api/v1/communications/email/messages/[message_id]/+server.ts
+++ b/src/routes/(api)/api/v1/communications/email/messages/[message_id]/+server.ts
@@ -21,12 +21,15 @@ export async function GET(event) {
 
 export async function PUT(event) {
 	try {
+		const generatePreview =
+			event.url.searchParams.get('generatePreview') === 'false' ? false : true;
 		const body = await event.request.json();
 		const updated = await api.update({
 			instanceId: event.locals.instance.id,
 			t: event.locals.t,
 			messageId: Number(event.params.message_id),
-			body
+			body,
+			queue: event.locals.queue
 		});
 		return json(updated);
 	} catch (err) {

--- a/src/routes/(api)/api/v1/communications/email/sends/+server.ts
+++ b/src/routes/(api)/api/v1/communications/email/sends/+server.ts
@@ -27,6 +27,7 @@ export async function POST(event) {
 			defaultTemplateId: event.locals.instance.settings.communications.email.default_template_id,
 			t: event.locals.t,
 			adminId: event.locals.admin.id,
+			queue: event.locals.queue,
 			body
 		});
 		return json(createdTemplate);

--- a/src/routes/(api)/worker/utils/openai/generate_email_preview/+server.ts
+++ b/src/routes/(api)/worker/utils/openai/generate_email_preview/+server.ts
@@ -1,0 +1,36 @@
+import { json, error } from '$lib/server';
+import { generateEmailPreview } from '$lib/server/utils/openai/schemas/emailPreview';
+import { emailPreviewOptions } from '$lib/schema/utils/openai';
+import { parse } from '$lib/schema/valibot';
+import {
+	read as readMessage,
+	update as updateMessage
+} from '$lib/server/api/communications/email/messages';
+
+export async function POST(event) {
+	try {
+		const body = await event.request.json();
+		const parsed = parse(emailPreviewOptions, body);
+		const message = await readMessage({
+			instanceId: event.locals.instance.id,
+			messageId: parsed.emailMessageId,
+			t: event.locals.t
+		});
+		const { preview } = await generateEmailPreview(message.subject, message.html);
+		await updateMessage({
+			instanceId: event.locals.instance.id,
+			messageId: parsed.emailMessageId,
+			body: { preview_text: preview },
+			queue: event.locals.queue,
+			t: event.locals.t
+		});
+		return json({ success: true });
+	} catch (err) {
+		return error(
+			500,
+			'WORKER:/worker/utils/openai/generate_html_meta/+server.ts',
+			event.locals.t.errors.http[500](),
+			err
+		);
+	}
+}


### PR DESCRIPTION
There was a prior PR with used OpenAI to automatically generate the HTML metatags for SEO and social media using the page content. 

This is a small PR to do the same thing for email preview text (basically the small bit of text which appears next to the subject as a preview in many email clients (including Gmail, Outlook, etc). 

Because we can use the same OpenAI integration as previously, the implementation was pretty straightforward. The main thing is making sure that the user can still manually provide a preview if required. 

This current implementation is imperfect, because if a user provides a manually created preview, saves it, then makes additional changes to the email and saves those changes again, the system _will_ trigger an automatic generation of new preview text which will overwrite their manually created one. I'm pretty sure avoiding this outcome would require a database migration to add a new flag for the `communications.email_messages` table, and given that this is a very low priority feature and custom preview text is very unlikely to be a priority for any of our users for the next year or so, I'm happy leaving it as is and coming back to it later. 