### PR TITLE
Removed error messages on load for new event and petition forms

### DIFF
--- a/src/routes/(app)/events/new/+page.server.ts
+++ b/src/routes/(app)/events/new/+page.server.ts
@@ -15,7 +15,8 @@ const log = pino('(app)/events/new/+page.server.ts');
 export async function load(event) {
 	const form = await superValidate(
 		{ ...event.locals.instance.settings.events.default_event_info_settings },
-		valibot(create)
+		valibot(create),
+		{ errors: false } //does not set errors on form load (tainted/dirty fields with errors will still display, though)
 	);
 	return { form };
 }

--- a/src/routes/(app)/petitions/new/+page.server.ts
+++ b/src/routes/(app)/petitions/new/+page.server.ts
@@ -16,7 +16,8 @@ const log = pino('(app)/events/new/+page.server.ts');
 export async function load(event) {
 	const form = await superValidate(
 		{ ...event.locals.instance.settings.events.default_event_info_settings },
-		valibot(create)
+		valibot(create),
+		{ errors: false } //does not set errors on form load (tainted/dirty fields with errors will still display, though)
 	);
 	return { form };
 }


### PR DESCRIPTION
Normally, SveltekitSuperforms doesn't display error messages for forms which don't have any pre-existing data. That is, even though the required fields might not currently be valid when the form loads, the error messages won't appear until after the user has edited the fields (ie: the fields are tainted by user input).

However, for the petition and event creation forms, we are populating the form with the default settings for events and petitions, which means that by default, SvelteKitSuperforms *will* show error messages on form load (see docs:
https://superforms.rocks/concepts/error-handling#seterror)

By setting the {errors: false} option in superValidate() in the form load function, SveltekitSuperforms will NOT show the error messages on load, but will continue to show error messages when form fields are tainted and invalid (ie: after user input). This is the behaviour we want.