### PR TITLE
Add AWS to connect-src CSP

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -14,7 +14,12 @@ const config = {
 			mode: 'auto',
 			directives: {
 				'default-src': ['self'],
-				'connect-src': ['self', '*.sentry.io', 'https://api-gateway.umami.dev/api/send'],
+				'connect-src': [
+					'self',
+					'*.sentry.io',
+					'https://api-gateway.umami.dev/api/send',
+					`https://*.amazonaws.com/`
+				],
 				// for now we need to keep 'unsafe-inline' for a couple of bits-ui components that inject inline event handlers
 				// we also need it for our custom code options, which currently inject inline styles.
 				'script-src': [
@@ -23,7 +28,7 @@ const config = {
 					'unsafe-inline',
 					'https://cloud.umami.is'
 				],
-        'frame-src': ['self', 'https://accounts.google.com'],
+				'frame-src': ['self', 'https://accounts.google.com'],
 				'frame-ancestors': ['self', 'https://accounts.google.com'],
 				'style-src': ['self', 'unsafe-inline', 'https://accounts.google.com/gsi/style'],
 				'worker-src': ['self', 'blob:'],


### PR DESCRIPTION
This is currently necessary for uploading to S3. I understand that *.amazonaws.com isn't exactly the ideal addition to the CSP and I'll see if we can find ways to narrow it down, but at the moment we're not tracking bucket region, and there's no way to write specific bucket URLs in a CSP directive without the region.