### PR TITLE
Set sentry environment

### DIFF
--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -6,8 +6,8 @@ Sentry.init({
 
 	// We recommend adjusting this value in production, or using tracesSampler
 	// for finer control
-	tracesSampleRate: 1.0,
-	enabled: !dev,
+	tracesSampleRate: dev ? 0 : 1.0,
+	environment: dev ? 'development' : 'production',
 	// Optional: Initialize Session Replay:
 	integrations: [Sentry.replayIntegration()],
 	replaysSessionSampleRate: 0.05,

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -23,8 +23,8 @@ Sentry.init({
 
 	// We recommend adjusting this value in production, or using tracesSampler
 	// for finer control
-	enabled: !dev, //not enabled in dev
-	tracesSampleRate: 1.0
+	tracesSampleRate: dev ? 0 : 1.0,
+	environment: dev ? 'development' : 'production'
 });
 const locale = new AsyncLocalStorage<SupportedLanguage>();
 export const handleError: HandleServerError = Sentry.handleErrorWithSentry();


### PR DESCRIPTION
Previously we were getting alerts sent from sentry for errors in development environment (eg: Validation errors, type errors, etc). Because these happen frequently in development and don't represent any problem, they were a lot of noise in Sentry email alerts. This ensures that Sentry understands these errors are development errors and the Sentry team account is configured to not surface these errors via alerts or in the main interface.