### PR TITLE
Always include lucide-svelte

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,9 @@ import { sentrySvelteKit } from '@sentry/sveltekit';
 import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
+	optimizeDeps: {
+		include: ['lucide-svelte']
+	},
 	plugins: [
 		sentrySvelteKit(),
 		sveltekit(),


### PR DESCRIPTION
Lucide-svelte is an icon library, and its large size seems to cause problems for Vite's dev server, probably around tree shaking during hot module reloading. If you dig into some of the errors when the dev server reloads randomly or even throws 500 errors that aren't related to the application code, it's usually a result of this library.

Adding this to the optimizeDeps.include config appears to make it more stable. But let's keep an eye on it and tweak further if we need to.