### PR TITLE
Patch/reminder email incident

### DIFF
--- a/src/lib/server/api/events/events.ts
+++ b/src/lib/server/api/events/events.ts
@@ -165,9 +165,9 @@ export async function update({
 	skipMetaGeneration?: boolean;
 }): Promise<schema.Read> {
 	const parsed = parse(schema.update, body);
-	const resultSql = db.update('events.events', parsed, { instance_id: instanceId, id: eventId });
-	log.debug(resultSql.compile().text);
-	const result = await resultSql.run(pool);
+	const result = await db
+		.update('events.events', parsed, { instance_id: instanceId, id: eventId })
+		.run(pool);
 	if (result.length !== 1) {
 		throw new BelcodaError(404, 'DATA:EVENTS:UPDATE:01', t.errors.not_found());
 	}

--- a/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
+++ b/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
@@ -48,6 +48,14 @@ async function queueEmailsToAttendees({
 }) {
 	for (let index = 0; index < eventObjects.length; index++) {
 		const eventObject = eventObjects[index];
+		await updateEvent({
+			instanceId: eventObject.instance_id,
+			eventId: eventObject.id,
+			body: { followup_sent_at: new Date(Date.now()) },
+			t: t,
+			queue: queue,
+			skipMetaGeneration: true
+		});
 		const attendees = await unsafeListAllForEvent({
 			instanceId: eventObject.instance_id,
 			eventId: eventObject.id
@@ -67,13 +75,5 @@ async function queueEmailsToAttendees({
 				);
 			}
 		}
-		await updateEvent({
-			instanceId: eventObject.instance_id,
-			eventId: eventObject.id,
-			body: { followup_sent_at: new Date(Date.now()) },
-			t: t,
-			queue: queue,
-			skipMetaGeneration: true
-		});
 	}
 }

--- a/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
+++ b/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
@@ -71,7 +71,9 @@ async function queueEmailsToAttendees({
 			instanceId: eventObject.instance_id,
 			eventId: eventObject.id,
 			body: { followup_sent_at: new Date(Date.now()) },
-			t: t
+			t: t,
+			queue: queue,
+			skipMetaGeneration: true
 		});
 	}
 }

--- a/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
+++ b/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
@@ -1,5 +1,6 @@
 import { json, error, pino } from '$lib/server';
 import { type TriggerEventMessage } from '$lib/schema/utils/email';
+import { type Update as UpdateEventSchema } from '$lib/schema/events/events';
 import {
 	selectEventsForReminderFollowupEmail,
 	update as updateEvent
@@ -48,10 +49,14 @@ async function queueEmailsToAttendees({
 }) {
 	for (let index = 0; index < eventObjects.length; index++) {
 		const eventObject = eventObjects[index];
+		const updateBody: UpdateEventSchema =
+			type === 'reminder'
+				? { reminder_sent_at: new Date(Date.now()) }
+				: { followup_sent_at: new Date(Date.now()) };
 		await updateEvent({
 			instanceId: eventObject.instance_id,
 			eventId: eventObject.id,
-			body: { followup_sent_at: new Date(Date.now()) },
+			body: updateBody,
 			t: t,
 			queue: queue,
 			skipMetaGeneration: true


### PR DESCRIPTION
This PR contains a number of small changes to the scheduled event emails handler, and the function to update events. 

The handler previously would trigger every 10 minutes (on a cron schedule) and check for any events that met the criteria to have either reminder emails or follow up emails sent out. The criteria were basically, `event.send_reminder_email === true` and `event.reminder_email_sent_at === null`, plus that the time window was appropriate for sending the notifications. 

Once it had the events, it would loop through them and trigger a function which would: 

1. Get all the people registered to attend the event
2. Queue an email to each person 
3. Update the event record noting the current Date() when the reminder was sent. 

This function had two problems. The first was that the same function was called for events that needed reminder emails sent and events that needed follow up emails sent. And in both contexts, it would _only update the `followup_email_sent_at` flag_ and leave the `reminder_email_sent_at` flag null. This meant that every ten minutes, the function would be triggered and find the same event still needing reminder emails sent, because the flag had not been sent. 

The second problem was that the updating event invocation was missing mandatory params that had been added in a recent refactor. This meant a ReferenceError was being thrown (albeit after the update function, which, if the first issue had not occured, would have updated the event). Because an unhandled error was thrown, the job failed, which meant the queue scheduled retried it, up to 25 times.

The combined effect of this bug was to trigger 25 emails to each person registered for the event, every 10 minutes. 

This PR fixes the problem by updating the function to send the emails to update the correct flag on the event record depending on the context it is called in, and to correctly invoke the update event function to avoid throwing errors. Additionally, for good measure, it sets the flag indicating the emails have been sent _before_ sending the emails, so that if that fails for some reason, the emails should not be sent. 