### PR TITLE
Make registered status the default for events

### DIFF
--- a/src/routes/(app)/events/[event_id]/register/RegisterPersonForm.svelte
+++ b/src/routes/(app)/events/[event_id]/register/RegisterPersonForm.svelte
@@ -12,7 +12,7 @@
 		'cancelled',
 		'noshow'
 	];
-	let status = $state(eventIsPast ? attendanceStatus[1] : attendanceStatus[0]);
+	let status = $state(attendanceStatus[0]);
 	const label = $derived($page.data.t.events.status[status]?.title() || 'Select status');
 	let sendNotifications: boolean = $state(true);
 </script>


### PR DESCRIPTION
This is based on feedback from the ROOTS team. When adding people to an event, "Registered" should be the default rather than "Attended".
Depending on use case, I see why we had "Attended" as the default for past events that you need to update. We'll probably need more feedback from users to know what works best for this one