### PR TITLE
Update with whatsapp registered template name

### DIFF
--- a/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
+++ b/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
@@ -51,11 +51,11 @@
 	async function saveThread() {
 		try {
 			loading = true;
-			if (template) {
+			if (template && templateMessage.type === 'template') {
 				await threadActions.updateThread({
 					templateMessage,
 					actions,
-					templateName: template.name,
+					templateName: templateMessage.template.name, //template
 					components,
 					messageId: data.thread.template_message_id
 				});


### PR DESCRIPTION
As a result of changes in the WhatsApp thread editing screens, a bug was introduced which overwrote the name of the template in the message body for template messages with the name of the template resource in the database (ie: the human readable name).

This name was different to the name of the template registered with WhatsApp/Meta, which led to TEMPLATE_NOT_FOUND errors being returned from the YCloud API.