### PR TITLE
Updated bits-ui to @next.98

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,7 @@
 				"@types/uuid": "^10.0.0",
 				"@vitest/ui": "^1.6.0",
 				"autoprefixer": "^10.4.19",
-				"bits-ui": "^1.0.0-next.84",
+				"bits-ui": "^1.0.0-next.98",
 				"dotenv": "^16.4.5",
 				"embla-carousel-svelte": "^8.5.1",
 				"eslint": "^9.0.0",
@@ -6975,9 +6975,9 @@
 			}
 		},
 		"node_modules/bits-ui": {
-			"version": "1.0.0-next.84",
-			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-1.0.0-next.84.tgz",
-			"integrity": "sha512-ZXsPfh/fOU1E2XvP8gRGk2G6c2vMWylDm3bCP888gwViI2lnwxz7D/fMuzBp3oKzovNxWMr8GR27yJQVOd9/jg==",
+			"version": "1.0.0-next.98",
+			"resolved": "https://registry.npmjs.org/bits-ui/-/bits-ui-1.0.0-next.98.tgz",
+			"integrity": "sha512-DYJNoi3pqLiJqmnOeKJp8dSmACu7yONmcoH6YqzrGnIQTgJ4bqL1D1C8gvDoUhWnCAtUWJ8fgyp9d25iOQAkiA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6986,7 +6986,8 @@
 				"@internationalized/date": "^3.5.6",
 				"esm-env": "^1.1.2",
 				"runed": "^0.23.2",
-				"svelte-toolbelt": "^0.7.1"
+				"svelte-toolbelt": "^0.7.1",
+				"tabbable": "^6.2.0"
 			},
 			"engines": {
 				"node": ">=18",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@types/uuid": "^10.0.0",
 		"@vitest/ui": "^1.6.0",
 		"autoprefixer": "^10.4.19",
-		"bits-ui": "^1.0.0-next.84",
+		"bits-ui": "^1.0.0-next.98",
 		"dotenv": "^16.4.5",
 		"embla-carousel-svelte": "^8.5.1",
 		"eslint": "^9.0.0",


### PR DESCRIPTION
This release appears to have fixed the underlying bug which is to do with a race condition in onfocus functions between dialog and dropdown components leading to an infinite loop in some circumstances.

I feel a bit uneasy because I was never able to create a minimal reproduction outside the context of the Belcoda app, and the issues described by other people weren't exactly what we had been experiencing, however, it was very close to what we experienced (and in the exact same circumstances, ie: a dropdown inside a dialog).

The bits-ui maintainer says that release 93 finally fixes this long-standing bug (see:
https://github.com/huntabyte/bits-ui/issues/913). Prior to this version bump, I was able to experience the bug fairly reliably (but not always). Since the version bump I've not experienced it once.