### PR TITLE
Feature/printable event sheets

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "Choose your language",
-	"tidy_watery_ape_lift": "Create new message"
+	"tidy_watery_ape_lift": "Create new message",
+	"equal_dull_kestrel_honor": "Cancelled",
+	"royal_civil_gull_succeed": "Additional attendees",
+	"same_fun_elephant_arrive": "Registered",
+	"upper_lime_giraffe_vent": "Attended",
+	"east_gray_fly_enchant": "No show",
+	"icy_weird_albatross_read": "Name",
+	"factual_soft_gadfly_nudge": "Phone number",
+	"busy_shy_gopher_bake": "Email address",
+	"true_early_cow_pride": "Email address",
+	"stock_direct_mole_stir": "Status",
+	"orange_mad_deer_value": "Print"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "Elige tu idioma",
-	"tidy_watery_ape_lift": "Crear nuevo mensaje"
+	"tidy_watery_ape_lift": "Crear nuevo mensaje",
+	"equal_dull_kestrel_honor": "Cancelado",
+	"royal_civil_gull_succeed": "Asistentes adicionales",
+	"same_fun_elephant_arrive": "Registrado",
+	"upper_lime_giraffe_vent": "Asistió",
+	"east_gray_fly_enchant": "No se presentó",
+	"icy_weird_albatross_read": "Nombre",
+	"factual_soft_gadfly_nudge": "Número de teléfono",
+	"busy_shy_gopher_bake": "Dirección de correo electrónico",
+	"true_early_cow_pride": "Dirección de correo electrónico",
+	"stock_direct_mole_stir": "Estado",
+	"orange_mad_deer_value": "Imprimir"
 }

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "Choisissez votre langue",
-	"tidy_watery_ape_lift": "Créer un nouveau message"
+	"tidy_watery_ape_lift": "Créer un nouveau message",
+	"equal_dull_kestrel_honor": "Annulé",
+	"royal_civil_gull_succeed": "Participants supplémentaires",
+	"same_fun_elephant_arrive": "Inscrit",
+	"upper_lime_giraffe_vent": "Assisté",
+	"east_gray_fly_enchant": "Pas de présentation",
+	"icy_weird_albatross_read": "Nom",
+	"factual_soft_gadfly_nudge": "Numéro de téléphone",
+	"busy_shy_gopher_bake": "Adresse email",
+	"true_early_cow_pride": "Adresse email",
+	"stock_direct_mole_stir": "Statut",
+	"orange_mad_deer_value": "Imprimer"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "言語を選択してください",
-	"tidy_watery_ape_lift": "新しいメッセージを作成"
+	"tidy_watery_ape_lift": "新しいメッセージを作成",
+	"equal_dull_kestrel_honor": "キャンセル",
+	"royal_civil_gull_succeed": "追加出席者",
+	"same_fun_elephant_arrive": "登録済み",
+	"upper_lime_giraffe_vent": "出席した",
+	"east_gray_fly_enchant": "欠席",
+	"icy_weird_albatross_read": "名前",
+	"factual_soft_gadfly_nudge": "電話番号",
+	"busy_shy_gopher_bake": "電子メールアドレス",
+	"true_early_cow_pride": "電子メールアドレス",
+	"stock_direct_mole_stir": "状態",
+	"orange_mad_deer_value": "印刷"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "Escolha seu idioma",
-	"tidy_watery_ape_lift": "Criar nova mensagem"
+	"tidy_watery_ape_lift": "Criar nova mensagem",
+	"equal_dull_kestrel_honor": "Cancelado",
+	"royal_civil_gull_succeed": "Participantes adicionais",
+	"same_fun_elephant_arrive": "Registrado",
+	"upper_lime_giraffe_vent": "Frequentou",
+	"east_gray_fly_enchant": "Não comparecimento",
+	"icy_weird_albatross_read": "Nome",
+	"factual_soft_gadfly_nudge": "Número de telefone",
+	"busy_shy_gopher_bake": "Endereço de email",
+	"true_early_cow_pride": "Endereço de email",
+	"stock_direct_mole_stir": "Status",
+	"orange_mad_deer_value": "Imprimir"
 }

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "Chagua lugha yako",
-	"tidy_watery_ape_lift": "Unda ujumbe mpya"
+	"tidy_watery_ape_lift": "Unda ujumbe mpya",
+	"equal_dull_kestrel_honor": "Imeghairiwa",
+	"royal_civil_gull_succeed": "Washiriki wa ziada",
+	"same_fun_elephant_arrive": "Imesajiliwa",
+	"upper_lime_giraffe_vent": "Walihudhuria",
+	"east_gray_fly_enchant": "Hakuna onyesho",
+	"icy_weird_albatross_read": "Jina",
+	"factual_soft_gadfly_nudge": "Nambari ya simu",
+	"busy_shy_gopher_bake": "Anwani ya barua pepe",
+	"true_early_cow_pride": "Anwani ya barua pepe",
+	"stock_direct_mole_stir": "Hali",
+	"orange_mad_deer_value": "Chapisha"
 }

--- a/messages/th.json
+++ b/messages/th.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "เลือกภาษาของคุณ",
-	"tidy_watery_ape_lift": "สร้างข้อความใหม่"
+	"tidy_watery_ape_lift": "สร้างข้อความใหม่",
+	"equal_dull_kestrel_honor": "ยกเลิก",
+	"royal_civil_gull_succeed": "ผู้เข้าร่วมเพิ่มเติม",
+	"same_fun_elephant_arrive": "ลงทะเบียนแล้ว",
+	"upper_lime_giraffe_vent": "เข้าร่วม",
+	"east_gray_fly_enchant": "ไม่แสดง",
+	"icy_weird_albatross_read": "ชื่อ",
+	"factual_soft_gadfly_nudge": "เบอร์โทรศัพท์",
+	"busy_shy_gopher_bake": "ที่อยู่อีเมล์",
+	"true_early_cow_pride": "ที่อยู่อีเมล์",
+	"stock_direct_mole_stir": "สถานะ",
+	"orange_mad_deer_value": "พิมพ์"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -1,5 +1,16 @@
 {
 	"$schema": "https://inlang.com/schema/inlang-message-format",
 	"watery_such_jackal_flow": "选择您的语言",
-	"tidy_watery_ape_lift": "创建新消息"
+	"tidy_watery_ape_lift": "创建新消息",
+	"equal_dull_kestrel_honor": "取消",
+	"royal_civil_gull_succeed": "其他与会者",
+	"same_fun_elephant_arrive": "挂号的",
+	"upper_lime_giraffe_vent": "已参加",
+	"east_gray_fly_enchant": "沒有演出",
+	"icy_weird_albatross_read": "姓名",
+	"factual_soft_gadfly_nudge": "电话号码",
+	"busy_shy_gopher_bake": "电子邮件",
+	"true_early_cow_pride": "电子邮件",
+	"stock_direct_mole_stir": "地位",
+	"orange_mad_deer_value": "打印"
 }

--- a/src/lib/server/api/events/attendees.ts
+++ b/src/lib/server/api/events/attendees.ts
@@ -116,9 +116,10 @@ export async function unsafeListAllForEvent({
 	eventId: number;
 }) {
 	const result = await db
-		.select('events.attendees', { event_id: eventId }) //no pagination
+		.select('events.event_attendees_view', { event_id: eventId }) //no pagination
 		.run(pool);
-	return result;
+	const parsedResult = parse(schema.list.entries.items, result);
+	return parsedResult;
 }
 
 export async function listForEvent({

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import '../../app.css';
 	import MainNav from '$lib/comps/nav/menu-bar.svelte';
 	import BottomNav from '$lib/comps/nav/mobile/bottom-nav.svelte';
 	import Sidebar from '$lib/comps/nav/desktop/sidebar.svelte';

--- a/src/routes/(app)/events/[event_id]/+page.svelte
+++ b/src/routes/(app)/events/[event_id]/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	const { data } = $props();
+	import * as m from '$lib/paraglide/messages';
 	import PageHeader from '$lib/comps/layout/PageHeader.svelte';
 	import Button from '$lib/comps/ui/button/button.svelte';
 	import DataGrid from '$lib/comps/ui/custom/table/DataGrid.svelte';
@@ -94,9 +95,14 @@
 			</div>
 		{/snippet}
 		{#snippet headerButton()}
-			<Button href="/events/{data.event.id}/register"
-				>{data.t.events.attendees.register.title()}</Button
-			>
+			<div class="flex items-center gap-1">
+				<Button variant="outline" target="_blank" href="/events/{data.event.id}/print"
+					>{m.orange_mad_deer_value()}</Button
+				>
+				<Button href="/events/{data.event.id}/register"
+					>{data.t.events.attendees.register.title()}</Button
+				>
+			</div>
 		{/snippet}
 	</DataGrid>
 </div>

--- a/src/routes/(app)/events/[event_id]/print/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/print/+page.server.ts
@@ -1,0 +1,37 @@
+import {
+	superValidate,
+	message,
+	valibot,
+	redirect,
+	type Infer,
+	pino,
+	BelcodaError,
+	returnMessage,
+	loadError
+} from '$lib/server';
+
+import { read } from '$lib/schema/events/events';
+import { list as listForEvent, update as updateAttendee } from '$lib/schema/events/attendees';
+import { unsafeListAllForEvent } from '$lib/server/api/events/attendees.js';
+import { parse } from '$lib/schema/valibot';
+const log = pino('(app)/events/[event_id]/print/+page.server.ts');
+
+export async function load(event) {
+	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);
+	if (!response.ok) return loadError(response);
+	const eventBody = await response.json();
+	const parsedEvent = parse(read, eventBody);
+
+	// this is using an unsafe function which we don't need or want to expose through the public API.
+	// if someone wanted to replicate this functionality using the public API, they could do so via pagination.
+	const attendees = await unsafeListAllForEvent({
+		instanceId: event.locals.instance.id,
+		eventId: Number(event.params.event_id)
+	});
+
+	return {
+		event: parsedEvent,
+		attendees: attendees,
+		pageTitle: [{ key: 'EVENTNAME', title: parsedEvent.name }]
+	};
+}

--- a/src/routes/(app)/events/[event_id]/print/+page@.svelte
+++ b/src/routes/(app)/events/[event_id]/print/+page@.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+	import * as m from '$lib/paraglide/messages';
+	const { data } = $props();
+	import { page } from '$app/state';
+	import { type List } from '$lib/schema/events/attendees';
+	import * as Table from '$lib/comps/ui/table/index';
+	//Have to use parseInt because Number(page.url.searchParams.get('additionalRows')) returns 0 when null
+	const amountOfAdditionalRows = isNaN(parseInt(page.url.searchParams.get('additionalRows') || ''))
+		? 20
+		: Number(page.url.searchParams.get('additionalRows'));
+	const registered = $derived(() => {
+		return data.attendees.filter((attendee) => attendee.status === 'registered');
+	});
+	const attended = $derived(() => {
+		return data.attendees.filter((attendee) => attendee.status === 'attended');
+	});
+	const cancelled = $derived(() => {
+		return data.attendees.filter((attendee) => attendee.status === 'cancelled');
+	});
+
+	import { renderAddress } from '$lib/utils/text/address';
+	import { formatDateTimeRange, formatDate } from '$lib/utils/text/date';
+	import MapPin from 'lucide-svelte/icons/map-pin';
+	import CalendarClock from 'lucide-svelte/icons/calendar-clock';
+	import Link from 'lucide-svelte/icons/link';
+</script>
+
+<div class="max-w-4xl mx-auto py-8 px-4">
+	<div class="font-bold text-4xl">{data.event.heading}</div>
+
+	<div class="text-muted-foreground space-y-2 mt-3">
+		{#if renderAddress(data.event, data.t, data.instance.country).text.length > 0}<div
+				class="flex items-center gap-1.5"
+			>
+				<MapPin size={16} />
+				<a href={renderAddress(data.event, data.t, data.instance.country).url} target="_blank"
+					>{renderAddress(data.event, data.t, data.instance.country).text}</a
+				>
+			</div>{/if}
+		<div class="flex items-center gap-1.5">
+			<CalendarClock size={16} />
+			{formatDateTimeRange(data.event.starts_at, data.event.ends_at)}
+		</div>
+		{#if data.event.online}
+			<div class="flex items-center gap-1.5">
+				<Link size={16} />
+				<div>
+					<a href={data.event.online_url} target="_blank">{data.event.online_url}</a>
+					{#if data.event.online_instructions}
+						<div class="text-muted-foreground text-xs">
+							{data.event.online_instructions}
+						</div>
+					{/if}
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	{#if registered().length > 0}
+		<div class="text-lg font-bold mt-6 mb-3">{m.same_fun_elephant_arrive()}</div>
+		<Table.Root>
+			{@render tableHeader()}
+			<Table.Body>
+				{#each registered() as person}
+					{@render row(person)}
+				{/each}
+			</Table.Body>
+		</Table.Root>
+	{/if}
+
+	{#if attended().length > 0}
+		<div class="text-lg font-bold mt-6 mb-3">{m.upper_lime_giraffe_vent()}</div>
+		<Table.Root>
+			{@render tableHeader()}
+			<Table.Body>
+				{#each attended() as person}
+					{@render row(person)}
+				{/each}
+			</Table.Body>
+		</Table.Root>
+	{/if}
+
+	{#if cancelled().length > 0}
+		<div class="text-lg font-bold mt-6 mb-3">{m.equal_dull_kestrel_honor()}</div>
+		<Table.Root>
+			{@render tableHeader()}
+			<Table.Body>
+				{#each cancelled() as person}
+					{@render row(person)}
+				{/each}
+			</Table.Body>
+		</Table.Root>
+	{/if}
+
+	{#if amountOfAdditionalRows > 0}
+		<div class="text-lg font-bold mt-6 mb-3">{m.royal_civil_gull_succeed()}</div>
+		<Table.Root>
+			{@render tableHeader()}
+			<Table.Body>
+				{#each Array(amountOfAdditionalRows) as _, i}
+					{@render additionalRow()}
+				{/each}
+			</Table.Body>
+		</Table.Root>
+	{/if}
+</div>
+
+{#snippet tableHeader()}
+	<Table.Header>
+		<Table.Row>
+			<Table.Head>{m.icy_weird_albatross_read()}</Table.Head>
+			<Table.Head>{m.factual_soft_gadfly_nudge()}</Table.Head>
+			<Table.Head>{m.true_early_cow_pride()}</Table.Head>
+			<Table.Head>{m.stock_direct_mole_stir()}</Table.Head>
+		</Table.Row>
+	</Table.Header>
+{/snippet}
+
+{#snippet row(person: List['items'][0])}
+	<Table.Row>
+		<Table.Cell class="font-medium w-1/4">{person.full_name}</Table.Cell>
+		<Table.Cell class="w-1/4">{person.phone_number?.phone_number}</Table.Cell>
+		<Table.Cell class="w-1/4">{person.email?.email}</Table.Cell>
+		<Table.Cell class="text-right w-1/4">{@render attendanceStatus()}</Table.Cell>
+	</Table.Row>
+{/snippet}
+
+{#snippet additionalRow()}
+	<Table.Row>
+		<Table.Cell class="font-medium w-1/4"></Table.Cell>
+		<Table.Cell class="w-1/4"></Table.Cell>
+		<Table.Cell class="w-1/4"></Table.Cell>
+		<Table.Cell class="text-right ">{@render attendanceStatus()}</Table.Cell>
+	</Table.Row>
+{/snippet}
+
+{#snippet attendanceStatus()}
+	<div class="flex gap-4 text-left">
+		<div class="flex">
+			<div class="border border-black w-4 h-4 mr-2"></div>
+			<div class="text-sm font-medium">{m.upper_lime_giraffe_vent()}</div>
+		</div>
+		<div class="flex">
+			<div class="border border-black w-4 h-4 mr-2"></div>
+			<div class="text-sm font-medium">{m.east_gray_fly_enchant()}</div>
+		</div>
+	</div>
+{/snippet}

--- a/src/routes/(app)/events/[event_id]/print/+page@.svelte
+++ b/src/routes/(app)/events/[event_id]/print/+page@.svelte
@@ -141,13 +141,13 @@
 
 {#snippet attendanceStatus()}
 	<div class="flex gap-4 text-left">
-		<div class="flex">
-			<div class="border border-black w-4 h-4 mr-2"></div>
-			<div class="text-sm font-medium">{m.upper_lime_giraffe_vent()}</div>
+		<div>
+			<div class="flex justify-center mb-1"><div class="border border-black w-4 h-4"></div></div>
+			<div class="text-xs font-medium">{m.upper_lime_giraffe_vent()}</div>
 		</div>
-		<div class="flex">
-			<div class="border border-black w-4 h-4 mr-2"></div>
-			<div class="text-sm font-medium">{m.east_gray_fly_enchant()}</div>
+		<div>
+			<div class="flex justify-center mb-1"><div class="border border-black w-4 h-4"></div></div>
+			<div class="text-xs font-medium">{m.east_gray_fly_enchant()}</div>
 		</div>
 	</div>
 {/snippet}

--- a/src/routes/(app)/events/[event_id]/print/+page@.svelte
+++ b/src/routes/(app)/events/[event_id]/print/+page@.svelte
@@ -23,6 +23,11 @@
 	import MapPin from 'lucide-svelte/icons/map-pin';
 	import CalendarClock from 'lucide-svelte/icons/calendar-clock';
 	import Link from 'lucide-svelte/icons/link';
+
+	import { onMount } from 'svelte';
+	onMount(() => {
+		window.print();
+	});
 </script>
 
 <div class="max-w-4xl mx-auto py-8 px-4">

--- a/src/routes/(utility)/+layout.svelte
+++ b/src/routes/(utility)/+layout.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import '../../app.css';
 	import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
 </script>
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,0 +1,6 @@
+<script lang="ts">
+	import '../app.css';
+	const { children } = $props();
+</script>
+
+{@render children()}


### PR DESCRIPTION
When people run events, sometimes they want to take attendance at the door (ie: mark down who actually came and who didn't). 

It's best to do that on a phone or laptop, but that's not always possible and sometimes paper is easier. Therefore, this printable view will allow people on the door at an event to print out a sheet with all the registered attendees, and a place to record whether they showed up or not, as well as a place to record additional attendees (ie: who didn't register). 