### PR TITLE
Adds a starting zero to 0 and 5 minute intervals

### DIFF
--- a/src/lib/comps/ui/form/datetime/datetime.svelte
+++ b/src/lib/comps/ui/form/datetime/datetime.svelte
@@ -60,7 +60,7 @@
 
 	const minuteOptions = Array.from({ length: 60 / minuteSteps }, (_, i) => ({
 		value: i * minuteSteps,
-		label: (i * minuteSteps).toString()
+		label: (i * minuteSteps).toString().padStart(2, '0')
 	}));
 
 	const hourOptions = Array.from({ length: 24 }, (_, i) => ({

--- a/src/lib/utils/text/date.ts
+++ b/src/lib/utils/text/date.ts
@@ -1,4 +1,7 @@
 import { DateFormatter } from '@internationalized/date';
+
+import { getLocale } from '$lib/paraglide/runtime';
+
 const df = new DateFormatter('en-US', {
 	dateStyle: 'long'
 });
@@ -15,7 +18,12 @@ export function formatDateOnly(date: Date): string {
 }
 
 export function formatDateTimeRange(startDate: Date, endDate: Date): string {
-	return `${tf.format(startDate)} - ${tf.format(endDate)}, ${df.format(startDate)} `;
+	const locale = getLocale();
+	const formatted = new Intl.DateTimeFormat(locale, {
+		timeZoneName: 'long'
+	}).formatToParts(startDate);
+	const timeZone = formatted.find((part) => part.type === 'timeZoneName')?.value;
+	return `${tf.format(startDate)} - ${tf.format(endDate)}, ${df.format(startDate)} (${timeZone}) `;
 }
 
 export function isToday(date: Date): boolean {


### PR DESCRIPTION
This was a request from the Roots team as a simple improvement to the event time editing interface. It might be replaced by the new Datetime widget, but it was very easy to implement.