### PR TITLE
Patch/test email improvements

### DIFF
--- a/src/lib/comps/forms/EditEmailMessageForm.svelte
+++ b/src/lib/comps/forms/EditEmailMessageForm.svelte
@@ -77,6 +77,17 @@
 				messageId,
 				successMessage: page.data.t.forms.actions.success(),
 				errorMessage: page.data.t.forms.actions.failed(),
+				updateMessage: {
+					name: $nameValue as string,
+					from: $fromValue as string,
+					reply_to: $replyToValue as string,
+					preview_text: $previewTextValue as string,
+					subject: $subjectValue as string,
+					html: $htmlValue as string,
+					text: $textValue as string,
+					use_html_for_plaintext: $useHtmlAsTextValue as boolean,
+					template_id: $templateIdValue as number
+				},
 				message: {
 					id: messageId,
 					name: $nameValue as string,

--- a/src/lib/comps/forms/EditEmailMessageForm.svelte
+++ b/src/lib/comps/forms/EditEmailMessageForm.svelte
@@ -233,9 +233,6 @@
 		{:else}
 			<Card.Content>
 				<InputWidget bind:value={testEmail} />
-				<div class="text-muted-foreground mt-1">
-					{page.data.t.forms.fields.email.send_test_email.description()}
-				</div>
 			</Card.Content>
 			<Card.Footer>
 				<Button type="button" onclick={() => triggerTestSend()}

--- a/src/lib/comps/forms/EditEmailMessageForm.svelte
+++ b/src/lib/comps/forms/EditEmailMessageForm.svelte
@@ -3,8 +3,9 @@
 </script>
 
 <script lang="ts" generics="T extends Record<string, unknown>">
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { getFlash } from 'sveltekit-flash-message';
+	import Loading from '$lib/comps/helpers/Loading.svelte';
 	const flash = getFlash(page);
 	import {
 		formFieldProxy,
@@ -15,6 +16,7 @@
 	import type { List as ListTemplates } from '$lib/schema/communications/email/templates';
 	export let messageId: number;
 	export let disabled: boolean = false;
+	export let loading: boolean = false;
 	export let form: SuperForm<T>;
 	export let name: FormPathLeaves<T>;
 	export let templateId: FormPathLeaves<T, number>;
@@ -68,29 +70,40 @@
 	import Separator from '$lib/comps/ui/separator/separator.svelte';
 
 	async function triggerTestSend() {
-		const result = await sendTestEmail({
-			email: testEmail,
-			messageId,
-			successMessage: $page.data.t.forms.actions.success(),
-			errorMessage: $page.data.t.forms.actions.failed(),
-			message: {
-				id: messageId,
-				name: $nameValue as string,
-				from: $fromValue as string,
-				reply_to: $replyToValue as string,
-				preview_text: $previewTextValue as string,
-				subject: $subjectValue as string,
-				html: $htmlValue as string,
-				text: $textValue as string,
-				use_html_for_plaintext: $useHtmlAsTextValue as boolean,
-				template_id: $templateIdValue as number,
-				point_person_id: $page.data.admin.id,
-				created_at: new Date(),
-				updated_at: new Date()
-			},
-			context: {}
-		});
-		$flash = result;
+		try {
+			loading = true;
+			const result = await sendTestEmail({
+				email: testEmail,
+				messageId,
+				successMessage: page.data.t.forms.actions.success(),
+				errorMessage: page.data.t.forms.actions.failed(),
+				message: {
+					id: messageId,
+					name: $nameValue as string,
+					from: $fromValue as string,
+					reply_to: $replyToValue as string,
+					preview_text: $previewTextValue as string,
+					subject: $subjectValue as string,
+					html: $htmlValue as string,
+					text: $textValue as string,
+					use_html_for_plaintext: $useHtmlAsTextValue as boolean,
+					template_id: $templateIdValue as number,
+					point_person_id: page.data.admin.id,
+					created_at: new Date(),
+					updated_at: new Date()
+				},
+				context: {}
+			});
+			$flash = result;
+		} catch (err) {
+			console.log(err);
+			$flash = {
+				type: 'error',
+				message: page.data.t.forms.actions.failed()
+			};
+		} finally {
+			loading = false;
+		}
 	}
 </script>
 
@@ -100,7 +113,7 @@
 			{disabled}
 			{form}
 			{name}
-			label={$page.data.t.forms.fields.generic.name.label()}
+			label={page.data.t.forms.fields.generic.name.label()}
 			bind:value={$nameValue as string}
 		/>
 	{/if}
@@ -109,7 +122,7 @@
 		{disabled}
 		{form}
 		name={subject}
-		label={$page.data.t.forms.fields.email.subject.label()}
+		label={page.data.t.forms.fields.email.subject.label()}
 		bind:value={$subjectValue as string}
 	/>
 
@@ -117,8 +130,8 @@
 		<div class="flex justify-end items-center gap-2">
 			<Label class="text-muted-foreground"
 				>{editHTML
-					? $page.data.t.forms.fields.generic.html.label()
-					: $page.data.t.forms.fields.generic.plain_text.label()}</Label
+					? page.data.t.forms.fields.generic.html.label()
+					: page.data.t.forms.fields.generic.plain_text.label()}</Label
 			>
 			<SwitchWidget disabled={$useHtmlAsTextValue} bind:checked={editHTML} />
 		</div>
@@ -142,18 +155,18 @@
 <!-- Advanced settings -->
 <Collapsible.Root class="w-full space-y-2">
 	<div class="flex items-center justify-between space-x-4 px-4">
-		<h4 class="text-sm font-semibold">{$page.data.t.forms.buttons.advanced_settings()}</h4>
+		<h4 class="text-sm font-semibold">{page.data.t.forms.buttons.advanced_settings()}</h4>
 		<Collapsible.Trigger class={buttonVariants({ variant: 'ghost', size: 'sm', class: 'w-9 p-0' })}>
 			<ChevronsUpDown />
-			<span class="sr-only">{$page.data.t.forms.buttons.toggle()}</span>
+			<span class="sr-only">{page.data.t.forms.buttons.toggle()}</span>
 		</Collapsible.Trigger>
 	</div>
 	<Collapsible.Content class="space-y-2">
 		<Alert.Root>
 			<TriangleAlert class="size-4" />
-			<Alert.Title>{$page.data.t.common.alerts.heads_up()}</Alert.Title>
+			<Alert.Title>{page.data.t.common.alerts.heads_up()}</Alert.Title>
 			<Alert.Description class="text-muted-foreground mt-2">
-				{$page.data.t.forms.fields.email.advanced_settings.warning()}
+				{page.data.t.forms.fields.email.advanced_settings.warning()}
 			</Alert.Description>
 		</Alert.Root>
 		<Grid cols={1}>
@@ -161,8 +174,8 @@
 				{disabled}
 				{form}
 				name={from}
-				label={$page.data.t.forms.fields.email.from.label()}
-				description={$page.data.t.forms.fields.email.from.description()}
+				label={page.data.t.forms.fields.email.from.label()}
+				description={page.data.t.forms.fields.email.from.description()}
 				bind:value={$fromValue as string}
 			/>
 
@@ -170,8 +183,8 @@
 				{disabled}
 				{form}
 				name={replyTo}
-				label={$page.data.t.forms.fields.email.reply_to.label()}
-				description={$page.data.t.forms.fields.email.reply_to.description()}
+				label={page.data.t.forms.fields.email.reply_to.label()}
+				description={page.data.t.forms.fields.email.reply_to.description()}
 				bind:value={$replyToValue as string}
 			/>
 
@@ -179,8 +192,8 @@
 				{disabled}
 				{form}
 				name={previewText}
-				label={$page.data.t.forms.fields.email.preview_text.label()}
-				description={$page.data.t.forms.fields.email.preview_text.description()}
+				label={page.data.t.forms.fields.email.preview_text.label()}
+				description={page.data.t.forms.fields.email.preview_text.description()}
 				bind:value={$previewTextValue as string}
 			/>
 
@@ -189,8 +202,8 @@
 			<Checkbox
 				{form}
 				name={useHtmlAsText}
-				label={$page.data.t.forms.fields.email.useHtmlAsPlainText.label()}
-				description={$page.data.t.forms.fields.email.useHtmlAsPlainText.description()}
+				label={page.data.t.forms.fields.email.useHtmlAsPlainText.label()}
+				description={page.data.t.forms.fields.email.useHtmlAsPlainText.description()}
 				bind:checked={$useHtmlAsTextValue as boolean}
 			/>
 		</Grid>
@@ -202,26 +215,30 @@
 	<Separator class="my-6" />
 	<Card.Root class="mb-6">
 		<Card.Header>
-			<Card.Title>{$page.data.t.forms.fields.email.send_test_email.label()}</Card.Title>
+			<Card.Title>{page.data.t.forms.fields.email.send_test_email.label()}</Card.Title>
 		</Card.Header>
-		<Card.Content>
-			<InputWidget bind:value={testEmail} />
-			<div class="text-muted-foreground mt-1">
-				{$page.data.t.forms.fields.email.send_test_email.description()}
-			</div>
-		</Card.Content>
-		<Card.Footer>
-			<Button type="button" onclick={() => triggerTestSend()}
-				>{$page.data.t.forms.buttons.send()}</Button
-			>
-		</Card.Footer>
+		{#if loading}
+			<div class="my-12"><Loading /></div>
+		{:else}
+			<Card.Content>
+				<InputWidget bind:value={testEmail} />
+				<div class="text-muted-foreground mt-1">
+					{page.data.t.forms.fields.email.send_test_email.description()}
+				</div>
+			</Card.Content>
+			<Card.Footer>
+				<Button type="button" onclick={() => triggerTestSend()}
+					>{page.data.t.forms.buttons.send()}</Button
+				>
+			</Card.Footer>
+		{/if}
 	</Card.Root>
 {/if}
 
 {#snippet templateSelector()}
 	{#if templates.length > 0}
 		<div class="w-full mb-2">
-			<Label>{$page.data.t.forms.fields.email.template.label()}</Label>
+			<Label>{page.data.t.forms.fields.email.template.label()}</Label>
 			<Select.Root
 				type="single"
 				onValueChange={(val) => {
@@ -231,7 +248,7 @@
 			>
 				<Select.Trigger class="w-full">
 					{templates.find((t) => t.id === $templateIdValue)?.name ||
-						$page.data.t.forms.fields.email.template.label()}
+						page.data.t.forms.fields.email.template.label()}
 				</Select.Trigger>
 				<Select.Content>
 					{#each templates as template}
@@ -240,7 +257,7 @@
 				</Select.Content>
 			</Select.Root>
 			<div class="text-muted-foreground text-sm mt-1.5">
-				{$page.data.t.forms.fields.email.template.description()}
+				{page.data.t.forms.fields.email.template.description()}
 			</div>
 		</div>
 	{/if}

--- a/src/lib/comps/forms/actions/sendTestEmail.ts
+++ b/src/lib/comps/forms/actions/sendTestEmail.ts
@@ -1,7 +1,9 @@
 import {
 	type Read,
 	sendTestEmail as validateTestEmail,
-	type SendTestEmail
+	type SendTestEmail,
+	type Update,
+	update as validateUpdate
 } from '$lib/schema/communications/email/messages';
 import { parse } from '$lib/schema/valibot';
 import { instance } from 'valibot';
@@ -11,11 +13,22 @@ type SendTestEmailInputs = {
 	email: string | undefined;
 	messageId: number;
 	message: Read;
+	updateMessage: Update;
 	context: SendTestEmail['context'];
 };
 
 export async function sendTestEmail(options: SendTestEmailInputs) {
 	try {
+		//first save the email
+		const parsedUpdate = parse(validateUpdate, options.updateMessage);
+		const resultUpdate = await fetch(`/api/v1/communications/email/messages/${options.messageId}`, {
+			method: 'PUT',
+			body: JSON.stringify(parsedUpdate)
+		});
+		if (!resultUpdate.ok) {
+			return { message: options.errorMessage, type: 'error' };
+		}
+		//then send the email
 		if (options.email) {
 			const body: SendTestEmail = {
 				email: options.email,


### PR DESCRIPTION
This improves the user experience of sending test emails by: 

1. Saving the email prior to sending. Previously the user had to manually remember to save the message. 
2. Showing some UI feedback when a test email is triggered. This is partly adding a loading spinner, but also fixing a bug in the flash message which was introduced when we switched over to the `import {page} from '$app/state'` import for the page data, instead of using the old `$page` svelte 4 store. This will have impacted all client-side toast messages, so I've created a test to review all client side messages. 