### PR TITLE
Feature/logs to sentry

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
 				"node-pg-format": "^1.3.5",
 				"openai": "^4.78.1",
 				"pino": "^9.2.0",
+				"pino-sentry-transport": "^1.5.0",
 				"postgres": "^3.4.5",
 				"redis": "^4.6.14",
 				"runed": "^0.23.0",
@@ -7068,6 +7069,30 @@
 			"integrity": "sha512-gvW7InbIyF8AicrqWoptdW08pUxuhq8BEgowNajy9RhiE86fmGAGl+bLKo6oB8QP0CkqHLowfN0oJdKC/J6LbA==",
 			"dev": true
 		},
+		"node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
 		"node_modules/buffer-crc32": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
@@ -8072,6 +8097,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/events": {
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+			"integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.8.x"
+			}
+		},
 		"node_modules/execa": {
 			"version": "8.0.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-8.0.1.tgz",
@@ -8871,6 +8905,26 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/ieee754": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "BSD-3-Clause"
+		},
 		"node_modules/ignore": {
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -9620,6 +9674,13 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
 			"integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw=="
+		},
+		"node_modules/lodash.get": {
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+			"integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
+			"deprecated": "This package is deprecated. Use the optional chaining (?.) operator instead.",
+			"license": "MIT"
 		},
 		"node_modules/lodash.groupby": {
 			"version": "4.6.0",
@@ -10594,6 +10655,33 @@
 				"split2": "^4.0.0"
 			}
 		},
+		"node_modules/pino-sentry-transport": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/pino-sentry-transport/-/pino-sentry-transport-1.5.0.tgz",
+			"integrity": "sha512-n5pAQhZ+JtEaHueo/SRAJ8qUhka3QiccV9lJwGJZ+ys3OCtKlSYen473pOJTZDBpadEoDRP8fU+kHPlmRstP9A==",
+			"license": "MIT",
+			"dependencies": {
+				"lodash.get": "^4.4.2",
+				"pino-abstract-transport": "^1.2.0"
+			},
+			"engines": {
+				"node": "> 14"
+			},
+			"peerDependencies": {
+				"@sentry/node": "^7.0.0 || ^8.0.0 || ^9.0.0",
+				"pino": "^7.0.0 || ^8.0.0 || ^9.0.0"
+			}
+		},
+		"node_modules/pino-sentry-transport/node_modules/pino-abstract-transport": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-1.2.0.tgz",
+			"integrity": "sha512-Guhh8EZfPCfH+PMXAb6rKOjGQEoy0xlAIn+irODG5kgfYV+BQ0rGYYWTIel3P5mmyXqkYkPmdIkywsn6QKUR1Q==",
+			"license": "MIT",
+			"dependencies": {
+				"readable-stream": "^4.0.0",
+				"split2": "^4.0.0"
+			}
+		},
 		"node_modules/pino-std-serializers": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
@@ -10943,6 +11031,15 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-warning": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
@@ -11038,6 +11135,22 @@
 			"integrity": "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==",
 			"dependencies": {
 				"pify": "^2.3.0"
+			}
+		},
+		"node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/readdirp": {
@@ -11540,6 +11653,15 @@
 			"version": "3.8.0",
 			"resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
 			"integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w=="
+		},
+		"node_modules/string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.2.0"
+			}
 		},
 		"node_modules/string-width": {
 			"version": "4.2.3",

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
 		"node-pg-format": "^1.3.5",
 		"openai": "^4.78.1",
 		"pino": "^9.2.0",
+		"pino-sentry-transport": "^1.5.0",
 		"postgres": "^3.4.5",
 		"redis": "^4.6.14",
 		"runed": "^0.23.0",

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -9,7 +9,7 @@ import createDefaultInstance from '$lib/server/utils/install/default_instance';
 import { _count, _count as _countInstance } from '$lib/server/api/core/instances';
 process.on('warning', (e) => console.warn(e.stack));
 import { defineGetLocale, baseLocale } from '$lib/paraglide/runtime';
-const log = pino('hooks.server.ts');
+const log = pino(import.meta.url);
 import mainHandler from '$lib/server/hooks/handlers';
 
 import { default as queue } from '$lib/server/utils/queue/add_job';

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -18,9 +18,10 @@ import * as Sentry from '@sentry/sveltekit';
 import { type HandleServerError, type Handle } from '@sveltejs/kit';
 import { sequence } from '@sveltejs/kit/hooks';
 import { dev } from '$app/environment';
-Sentry.init({
-	dsn: 'https://8b4cdb05d7907fe3f9b43aec4a060811@o4508220361342976.ingest.de.sentry.io/4508220380282960',
+import { PUBLIC_SENTRY_DSN } from '$env/static/public';
 
+Sentry.init({
+	dsn: PUBLIC_SENTRY_DSN,
 	// We recommend adjusting this value in production, or using tracesSampler
 	// for finer control
 	tracesSampleRate: dev ? 0 : 1.0,
@@ -47,7 +48,6 @@ const localizationHandler: Handle = async ({ event, resolve }) => {
 
 const belcodaHandler: Handle = async ({ event, resolve }) => {
 	event.locals.queue = queue;
-
 	//get all instances. If the count is zero, run the install script... this is a one-time thing.
 	const instanceCount = await _countInstance();
 	if (!(instanceCount > 0)) {

--- a/src/lib/server/api/communications/email/sent_emails.ts
+++ b/src/lib/server/api/communications/email/sent_emails.ts
@@ -7,7 +7,7 @@ import {
 	redisString as personRedisString
 } from '$lib/server/api/people/people';
 import { type Read } from '$lib/schema/people/people';
-const log = pino('$lib/server/api/communications/email/sent_emails');
+const log = pino(import.meta.url);
 function redisString(instanceId: number, personId: number) {
 	return `i:${instanceId}:sent_emails:${personId}`;
 }

--- a/src/lib/server/api/communications/email/templates.ts
+++ b/src/lib/server/api/communications/email/templates.ts
@@ -1,7 +1,7 @@
 import { db, pool, redis, filterQuery, BelcodaError, pino } from '$lib/server';
 import * as schema from '$lib/schema/communications/email/templates';
 import { parse } from '$lib/schema/valibot';
-const log = pino('$lib/server/api/communications/email/templates');
+const log = pino(import.meta.url);
 
 function redisString(instanceId: number, templateId: number | 'all') {
 	return `i:${instanceId}:email_templates:${templateId}`;

--- a/src/lib/server/api/communications/whatsapp/sent_messages.ts
+++ b/src/lib/server/api/communications/whatsapp/sent_messages.ts
@@ -8,7 +8,7 @@ function redisString(instanceId: number, personId: number) {
 	return `i:${instanceId}:person:${personId}:sent_whatsapp_messages`;
 }
 
-const log = pino('data:/communications/whatsapp/sent_messages');
+const log = pino(import.meta.url);
 export async function create({
 	instanceId,
 	body,

--- a/src/lib/server/api/communications/whatsapp/threads.ts
+++ b/src/lib/server/api/communications/whatsapp/threads.ts
@@ -8,7 +8,7 @@ import { create as createMessage } from '$lib/server/api/communications/whatsapp
 function redisString(instanceId: number, templateId: number | 'all') {
 	return `i:${instanceId}:whatsapp_threads:${templateId}`;
 }
-const log = pino('api:communications:whatsapp:threads');
+const log = pino(import.meta.url);
 
 export async function exists({
 	instanceId,

--- a/src/lib/server/api/core/admins.ts
+++ b/src/lib/server/api/core/admins.ts
@@ -9,7 +9,7 @@ import type { Read as ReadInstance } from '$lib/schema/core/instance';
 import { create as createSession } from '$lib/server/api/core/sessions';
 import { read as readInstance } from '$lib/server/api/core/instances';
 
-const log = pino('$lib/server/api/core/admins');
+const log = pino(import.meta.url);
 
 const redisString = (instance_id: number, admin_id: number | 'all') =>
 	`i:${instance_id}:admin:${admin_id}`;

--- a/src/lib/server/api/core/sessions.ts
+++ b/src/lib/server/api/core/sessions.ts
@@ -1,6 +1,6 @@
 import { redis, db, pool, t, error, type SL, pino } from '$lib/server';
 
-const log = pino('$lib/server/api/core/sessions');
+const log = pino(import.meta.url);
 
 import * as schemaSession from '$lib/schema/core/session';
 import * as schemaAdmin from '$lib/schema/core/admin';

--- a/src/lib/server/api/events/attendees.ts
+++ b/src/lib/server/api/events/attendees.ts
@@ -3,7 +3,7 @@ import { parse } from '$lib/schema/valibot';
 import * as schema from '$lib/schema/events/attendees';
 import { exists } from '$lib/server/api/events/events';
 import { exists as personExists } from '$lib/server/api/people/people';
-const log = pino('API:/api/v1/events/attendees/+server.ts');
+const log = pino(import.meta.url);
 function redisString(instanceId: number, eventId: number, personId: number | 'all') {
 	return `i:${instanceId}:events:${eventId}:attendees:${personId}`;
 }

--- a/src/lib/server/api/events/events.ts
+++ b/src/lib/server/api/events/events.ts
@@ -9,7 +9,7 @@ import { type EventHTMLMetaTags } from '$lib/schema/utils/openai';
 import { read as readInstance } from '$lib/server/api/core/instances';
 import { create as createEmailMessage } from '$lib/server/api/communications/email/messages';
 
-const log = pino('DATA:/events/events');
+const log = pino(import.meta.url);
 
 export function redisString(instanceId: number, eventId: number | 'all') {
 	return `i:${instanceId}:events:${eventId}`;

--- a/src/lib/server/api/people/custom_field_values.ts
+++ b/src/lib/server/api/people/custom_field_values.ts
@@ -1,5 +1,5 @@
 import { db, pool, pino, redis, error, BelcodaError } from '$lib/server';
-const log = pino('$lib/server/api/people/custom_field_values');
+const log = pino(import.meta.url);
 import { read as readCustomField } from '$lib/server/api/people/custom_fields';
 import { readFieldValue } from '$lib/schema/people/custom_field_values';
 import { redisString } from '$lib/server/api/people/people';

--- a/src/lib/server/api/people/custom_fields.ts
+++ b/src/lib/server/api/people/custom_fields.ts
@@ -1,7 +1,7 @@
 import { db, pool, redis, error, BelcodaError, pino, filterQuery } from '$lib/server';
 //import * as schema from '$lib/schema/people/custom_fields';
 import { redisString } from '$lib/server/api/people/people';
-const log = pino('$lib/server/api/people/custom_fields');
+const log = pino(import.meta.url);
 
 import * as schema from '$lib/schema/people/custom_fields';
 import { parse } from '$lib/schema/valibot';

--- a/src/lib/server/api/people/filters/filters.ts
+++ b/src/lib/server/api/people/filters/filters.ts
@@ -8,7 +8,7 @@ import {
 import { list as listPeople, type List as ListPeople } from '$lib/schema/people/people';
 import { db, pool, filterQuery, pino } from '$lib/server';
 import { id, parse } from '$lib/schema/valibot';
-const log = pino('DATA:/server/api/people/filters/filters.ts');
+const log = pino(import.meta.url);
 
 export function generateSqlFromFilterArray(instanceId: number, filter: FilterType): string {
 	let sql = format(`SELECT id FROM people.people WHERE instance_id = %L AND id IN `, instanceId);

--- a/src/lib/server/api/people/people.ts
+++ b/src/lib/server/api/people/people.ts
@@ -13,7 +13,7 @@ import { whatsappNumberForVerification } from '$lib/schema/people/channels/chann
 export const redisString = (instance_id: number, person_id: number | 'all') =>
 	`i:${instance_id}:people:${person_id}`;
 
-const log = pino('$lib/server/api/people/people');
+const log = pino(import.meta.url);
 
 async function queueCustomFieldSet({
 	objectSchema,

--- a/src/lib/server/api/petitions/signatures.ts
+++ b/src/lib/server/api/petitions/signatures.ts
@@ -3,7 +3,7 @@ import { parse } from '$lib/schema/valibot';
 import * as schema from '$lib/schema/petitions/signatures';
 import { exists } from '$lib/server/api/petitions/petitions';
 import { exists as personExists } from '$lib/server/api/people/people';
-const log = pino('API:/api/v1/petitions/signatures/+server.ts');
+const log = pino(import.meta.url);
 function redisString(instanceId: number, petitionId: number, personId: number | 'all') {
 	return `i:${instanceId}:petitions:${petitionId}:signatures:${personId}`;
 }

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -2,7 +2,7 @@ import { UMAMI_API_KEY } from '$env/static/private';
 import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
 import { type RequestEvent } from '@sveltejs/kit';
 import { pino } from '$lib/server';
-const log = pino('$lib/server/hooks/analytics/log');
+const log = pino(import.meta.url);
 export default async function (event: RequestEvent): Promise<void> {
 	try {
 		const payload = {

--- a/src/lib/server/hooks/build_locals.ts
+++ b/src/lib/server/hooks/build_locals.ts
@@ -11,7 +11,7 @@ export function buildLocalLanguage(event: RequestEvent): SupportedLanguage {
 	return locale;
 }
 
-const log = pino('$lib/server/hooks/build_locals');
+const log = pino(import.meta.url);
 import logToAnalytics from '$lib/server/hooks/analytics/log';
 
 export async function buildAdminInstance({ event }: { event: RequestEvent }): Promise<{
@@ -67,7 +67,7 @@ export async function buildAdminInstance({ event }: { event: RequestEvent }): Pr
 		const { admin, instance } = await getSession(event);
 		event.locals.admin = admin;
 		event.locals.instance = instance;
-    //event.locals.language = instance.language; //don't overwrite user selected language with instance default
+		//event.locals.language = instance.language; //don't overwrite user selected language with instance default
 		return { authenticated: true, event, jsonResponse: false };
 	} catch (err) {
 		log.error(err);

--- a/src/lib/server/hooks/email/index.ts
+++ b/src/lib/server/hooks/email/index.ts
@@ -5,7 +5,7 @@ import { pino } from '$lib/server';
 import { incomingWebhook } from '$lib/schema/communications/email/received_emails';
 import { extract } from 'letterparser';
 import { Buffer } from 'buffer';
-const log = pino('$lib/server/hooks/email');
+const log = pino(import.meta.url);
 import { parse } from '$lib/schema/valibot';
 import { readBySubdomain } from '$lib/server/api/core/instances';
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {

--- a/src/lib/server/hooks/email/postmark.ts
+++ b/src/lib/server/hooks/email/postmark.ts
@@ -3,7 +3,7 @@ type Resolve = (event: RequestEvent, opts?: ResolveOptions | undefined) => Maybe
 import type { HandlerResponse } from '$lib/server/hooks/handlers';
 import { pino } from '$lib/server';
 import { incomingPostmarkWebhook } from '$lib/schema/communications/email/received_emails';
-const log = pino('$lib/server/hooks/email');
+const log = pino(import.meta.url);
 import { parse } from '$lib/schema/valibot';
 import { readBySubdomain } from '$lib/server/api/core/instances';
 import { POSTMARK_INBOUND_WEBHOOK_TOKEN } from '$env/static/private';

--- a/src/lib/server/hooks/handlers.ts
+++ b/src/lib/server/hooks/handlers.ts
@@ -1,7 +1,7 @@
 import { handleApiFaviconRequest } from '$lib/server/hooks/simple_handlers';
 import type { RequestEvent, ResolveOptions } from '@sveltejs/kit';
 import { pino } from '$lib/server';
-const log = pino('$lib/server/hooks/handlers');
+const log = pino(import.meta.url);
 import whatsappHandler from '$lib/server/hooks/whatsapp/ycloud';
 import whapiHandler from '$lib/server/hooks/whapi';
 import emailHandler from '$lib/server/hooks/email/postmark';

--- a/src/lib/server/hooks/website/handler.ts
+++ b/src/lib/server/hooks/website/handler.ts
@@ -9,7 +9,7 @@ import { default as handle_petition } from '$lib/server/hooks/website/handlers/p
 import { default as handle_content } from '$lib/server/hooks/website/handlers/content';
 
 import { pino } from '$lib/server';
-const log = pino('/lib/server/website_render/handler');
+const log = pino(import.meta.url);
 
 import { COOKIE_SESSION_NAME } from '$env/static/private';
 

--- a/src/lib/server/hooks/website/handlers/content.ts
+++ b/src/lib/server/hooks/website/handlers/content.ts
@@ -14,7 +14,7 @@ import {
 
 import { pino } from '$lib/server';
 
-const log = pino('/lib/server/hooks/website/handlers/content');
+const log = pino(import.meta.url);
 const error404 = {
 	title: 'Error',
 	error_code: 'Error 404',

--- a/src/lib/server/hooks/website/handlers/event.ts
+++ b/src/lib/server/hooks/website/handlers/event.ts
@@ -10,7 +10,7 @@ import {
 } from '$lib/server/hooks/website/render';
 
 import { pino } from '$lib/server';
-const log = pino('/lib/server/hooks/website/handlers/event');
+const log = pino(import.meta.url);
 const error404 = {
 	title: 'Error',
 	error_code: 'Error 404',

--- a/src/lib/server/hooks/website/handlers/petition.ts
+++ b/src/lib/server/hooks/website/handlers/petition.ts
@@ -9,7 +9,7 @@ import {
 	type RenderStatus
 } from '$lib/server/hooks/website/render';
 import { pino } from '$lib/server';
-const log = pino('/lib/server/hooks/website/handlers/event');
+const log = pino(import.meta.url);
 const error404 = {
 	title: 'Error',
 	error_code: 'Error 404',

--- a/src/lib/server/hooks/website/register_helpers.ts
+++ b/src/lib/server/hooks/website/register_helpers.ts
@@ -1,6 +1,6 @@
 import Handlebars from 'handlebars';
 import { pino } from '$lib/server';
-const log = pino('/lib/server/website_render/register_helpers');
+const log = pino(import.meta.url);
 import { type Read } from '$lib/schema/website/blocks';
 import { type Read as EventRead } from '$lib/schema/events/events';
 

--- a/src/lib/server/hooks/website/render.ts
+++ b/src/lib/server/hooks/website/render.ts
@@ -12,7 +12,7 @@ import type { Read as ReadEvent } from '$lib/schema/events/events';
 import type { Read as ReadPetition } from '$lib/schema/petitions/petitions';
 
 import { pino } from '$lib/server';
-const log = pino(`/server/website_render/render.ts`);
+const log = pino(import.meta.url);
 
 export function compile_custom_code(content: unknown, template: unknown) {
 	const customCode = parse(customCodeSchema, content);

--- a/src/lib/server/hooks/whapi/index.ts
+++ b/src/lib/server/hooks/whapi/index.ts
@@ -6,7 +6,7 @@ import { parse } from '$lib/schema/valibot';
 import { _getInstanceIdByWhatsappGroupChatId } from '$lib/server/api/people/groups';
 import { read } from '$lib/server/api/core/instances';
 import { pino } from '$lib/server';
-const log = pino('$lib/server/hooks/whapi/...');
+const log = pino(import.meta.url);
 
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {
 	try {

--- a/src/lib/server/hooks/whatsapp/index.ts
+++ b/src/lib/server/hooks/whatsapp/index.ts
@@ -9,7 +9,7 @@ import { parse } from '$lib/schema/valibot';
 import { webhook } from '$lib/schema/communications/whatsapp/webhooks/webhook';
 import { _getInstanceByWhatsappPhoneNumberId } from '$lib/server/api/core/instances';
 
-const log = pino('$lib/server/hooks/whatsapp');
+const log = pino(import.meta.url);
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {
 	log.info(`📞 ${event.request.method} ${event.url.href}`);
 	const challenge = event.url.searchParams.get('hub.challenge');

--- a/src/lib/server/hooks/whatsapp/ycloud.ts
+++ b/src/lib/server/hooks/whatsapp/ycloud.ts
@@ -14,7 +14,7 @@ import {
 import { _getSentWhatsappMessageById } from '$lib/server/api/communications/whatsapp/sent_messages';
 import { _getInstanceIdByPersonId } from '$lib/server/api/people/people';
 
-const log = pino('$lib/server/hooks/whatsapp/ycloud');
+const log = pino(import.meta.url);
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {
 	log.info(`📞 ${event.request.method} ${event.url.pathname}`);
 	if (event.url.searchParams.get('verify') !== YCLOUD_VERIFY_TOKEN) {

--- a/src/lib/server/hooks/worker.ts
+++ b/src/lib/server/hooks/worker.ts
@@ -1,6 +1,6 @@
 import type { MaybePromise, RequestEvent, ResolveOptions } from '@sveltejs/kit';
 import { pino } from '$lib/server';
-const log = pino('$lib/server/hooks/handlers');
+const log = pino(import.meta.url);
 import { buildAdminInstance } from '$lib/server/hooks/build_locals';
 
 import { buildLocalLanguage } from '$lib/server/hooks/build_locals';

--- a/src/lib/server/index.ts
+++ b/src/lib/server/index.ts
@@ -7,7 +7,7 @@ export { json } from '@sveltejs/kit';
 export { filterQuery } from '$lib/server/utils/filters/filter';
 
 import { pino } from '$lib/server';
-const log = pino('$lib/server/errors');
+const log = pino(import.meta.url);
 import { error as returnError, type NumericRange } from '@sveltejs/kit';
 import { randomUUID } from 'crypto';
 import { renderValiError } from '$lib/schema/valibot';

--- a/src/lib/server/utils/db/index.ts
+++ b/src/lib/server/utils/db/index.ts
@@ -8,6 +8,9 @@ import pg from 'pg';
 
 import CERT from '$lib/server/utils/db/cert';
 
+import { pino } from '$lib/server/utils/logs/pino';
+const log = pino(import.meta.url);
+
 const pool = dev
 	? new pg.Pool({
 			host: PGHOST,
@@ -23,7 +26,7 @@ const pool = dev
 			ssl: { ca: CERT, rejectUnauthorized: false }
 		});
 
-pool.on('error', (err) => console.error(err)); // don't let a pg restart kill your app
-pool.on('connect', () => console.log('😇 Database connected'));
+pool.on('error', (err) => log.error(err, '❌ Error in the database pool')); // don't let a pg restart kill your app
+pool.on('connect', () => log.trace('😇 Database connected'));
 db.setConfig({ castArrayParamsToJson: true, castObjectParamsToJson: true });
 export { pool, db, type s };

--- a/src/lib/server/utils/email/send_email_postmark.ts
+++ b/src/lib/server/utils/email/send_email_postmark.ts
@@ -1,7 +1,7 @@
 import { POSTMARK_SERVER_TOKEN } from '$env/static/private';
 import type { NumericRange } from '@sveltejs/kit';
 import { BelcodaError, pino } from '$lib/server';
-const log = pino('/utils/email/send_email_postmark');
+const log = pino(import.meta.url);
 export default async function (options: {
 	to: string;
 	from: string;

--- a/src/lib/server/utils/install/data/test/testData.ts
+++ b/src/lib/server/utils/install/data/test/testData.ts
@@ -1,5 +1,5 @@
 import { pino } from '$lib/server';
-const log = pino('utils:install:testData');
+const log = pino(import.meta.url);
 import { parse } from '$lib/schema/valibot';
 import { create as createEvent } from '$lib/server/api/events/events';
 import { create as createPetition } from '$lib/server/api/petitions/petitions';

--- a/src/lib/server/utils/install/index.ts
+++ b/src/lib/server/utils/install/index.ts
@@ -39,7 +39,7 @@ import createInstanceSettings from '$lib/server/utils/install/default_instance_s
 
 import createTestData from '$lib/server/utils/install/data/test/testData';
 
-const log = pino('utils:install');
+const log = pino(import.meta.url);
 
 export default async function install(
 	options: InstallOptions,

--- a/src/lib/server/utils/logs/pino.ts
+++ b/src/lib/server/utils/logs/pino.ts
@@ -1,5 +1,29 @@
 import { default as pino_instance } from 'pino';
 import { LOG_LEVEL } from '$env/static/private';
-export function pino(name: string) {
-	return pino_instance({ name, level: LOG_LEVEL ?? 'info' });
+import { PUBLIC_SENTRY_DSN } from '$env/static/public';
+import { dev } from '$app/environment';
+
+const logger = dev
+	? pino_instance({ level: LOG_LEVEL ?? 'debug' })
+	: pino_instance({
+			level: LOG_LEVEL ?? 'debug',
+			transport: {
+				target: 'pino-sentry-transport',
+				options: {
+					sentry: {
+						dsn: PUBLIC_SENTRY_DSN, // sentry dsn
+						environment: dev ? 'development' : 'production'
+						// additional options for sentry
+					},
+					withLogRecord: true, // default false - send the entire log record to sentry as a context.(FYI if its more then 8Kb Sentry will throw an error)
+					tags: ['level'], // sentry tags to add to the event, uses lodash.get to get the value from the log record
+					context: ['hostname'], // sentry context to add to the event, uses lodash.get to get the value from the log record,
+					minLevel: 40 // which level to send to sentry
+				}
+			}
+		});
+
+export function pino(file: string) {
+	const child = logger.child({ file });
+	return child;
 }

--- a/src/lib/server/utils/queue/init.ts
+++ b/src/lib/server/utils/queue/init.ts
@@ -1,6 +1,6 @@
 import { makeWorkerUtils } from 'graphile-worker';
 import { pool, pino } from '$lib/server';
-const log = pino('$lib/server/utils/queue');
+const log = pino(import.meta.url);
 async function main() {
 	const workerUtils = await makeWorkerUtils({
 		pgPool: pool

--- a/src/lib/server/utils/redis.ts
+++ b/src/lib/server/utils/redis.ts
@@ -7,7 +7,7 @@ const CACHE_PREFIX: string = 'bc:';
 import { error, pino } from '$lib/server';
 import { building, dev } from '$app/environment';
 
-const log = pino('$lib/server/utils/redis');
+const log = pino(import.meta.url);
 
 const client = dev
 	? createClient({ url: REDIS_URL })

--- a/src/lib/server/utils/whapi/apiClient.ts
+++ b/src/lib/server/utils/whapi/apiClient.ts
@@ -2,7 +2,7 @@ import { WHAPI_API_URL, WHAPI_API_TOKEN } from '$env/static/private';
 import { BelcodaError } from '$lib/server';
 import type { NumericRange } from '@sveltejs/kit';
 import { pino } from '$lib/server';
-const log = pino('/server/utils/whapi/apiClient');
+const log = pino(import.meta.url);
 export async function apiClient({
 	method,
 	endpoint,

--- a/src/routes/(api)/api/v1/admins/+server.ts
+++ b/src/routes/(api)/api/v1/admins/+server.ts
@@ -4,7 +4,7 @@ import * as schema from '$lib/schema/core/admin';
 import { parse } from '$lib/schema/valibot';
 import * as api from '$lib/server/api/core/admins';
 
-const log = pino('$lib/server/api/v1/admins');
+const log = pino(import.meta.url);
 
 export async function POST(event) {
 	try {

--- a/src/routes/(api)/api/v1/events/+server.ts
+++ b/src/routes/(api)/api/v1/events/+server.ts
@@ -2,7 +2,7 @@ import { json, BelcodaError, pino, error } from '$lib/server';
 import * as api from '$lib/server/api/events/events';
 import * as schema from '$lib/schema/events/events';
 import { parse } from '$lib/schema/valibot';
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 export async function GET(event) {
 	try {
 		const response = await api.list({

--- a/src/routes/(api)/api/v1/events/[event_id]/+server.ts
+++ b/src/routes/(api)/api/v1/events/[event_id]/+server.ts
@@ -2,7 +2,7 @@ import { json, error, pino } from '$lib/server';
 import * as api from '$lib/server/api/events/events';
 import * as schema from '$lib/schema/events/events';
 import { parse } from '$lib/schema/valibot';
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 
 export async function GET(event) {
 	try {

--- a/src/routes/(api)/api/v1/events/[event_id]/attendees/+server.ts
+++ b/src/routes/(api)/api/v1/events/[event_id]/attendees/+server.ts
@@ -4,7 +4,7 @@ import * as schema from '$lib/schema/events/attendees';
 import { parse } from '$lib/schema/valibot';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
 import { read as readEvent } from '$lib/server/api/events/events';
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 export async function GET(event) {
 	try {
 		const response = await api.listForEvent({

--- a/src/routes/(api)/api/v1/events/[event_id]/attendees/[person_id]/+server.ts
+++ b/src/routes/(api)/api/v1/events/[event_id]/attendees/[person_id]/+server.ts
@@ -5,7 +5,7 @@ import { parse } from '$lib/schema/valibot';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
 import { read as readEvent } from '$lib/server/api/events/events';
 
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 
 export async function GET(event) {
 	try {

--- a/src/routes/(api)/api/v1/people/[person_id]/communication/whatsapp/send_message/+server.ts
+++ b/src/routes/(api)/api/v1/people/[person_id]/communication/whatsapp/send_message/+server.ts
@@ -4,7 +4,7 @@ import { getActiveForPerson } from '$lib/server/api/communications/whatsapp/conv
 import { create } from '$lib/server/api/communications/whatsapp/messages';
 import { type Create } from '$lib/schema/communications/whatsapp/messages';
 
-const log = pino('/api/v1/people/[person_id]/communications/whatsapp/send_message/+server.ts');
+const log = pino(import.meta.url);
 
 export async function POST(event) {
 	try {

--- a/src/routes/(api)/api/v1/people/[person_id]/custom_fields/values/+server.ts
+++ b/src/routes/(api)/api/v1/people/[person_id]/custom_fields/values/+server.ts
@@ -4,7 +4,7 @@ import { setCustomFieldValue } from '$lib/server/api/people/custom_field_values'
 import { setFieldValueFromApi } from '$lib/schema/people/custom_field_values';
 import { parse } from '$lib/schema/valibot';
 
-const log = pino('/api/v1/people/custom_fields/values/:person_id/custom_fields/values');
+const log = pino(import.meta.url);
 
 export async function PUT(event) {
 	try {

--- a/src/routes/(api)/api/v1/people/filter/+server.ts
+++ b/src/routes/(api)/api/v1/people/filter/+server.ts
@@ -2,7 +2,7 @@ import { json, error, pino } from '$lib/server';
 import { filterGroup } from '$lib/schema/people/filters/filters';
 import { parse } from '$lib/schema/valibot';
 import { outputFilterResults } from '$lib/server/api/people/filters/filters.js';
-const log = pino('API:/api/v1/people/[person_id]/filters/+server.ts');
+const log = pino(import.meta.url);
 export async function PUT(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/api/v1/people/filter/create_list/+server.ts
+++ b/src/routes/(api)/api/v1/people/filter/create_list/+server.ts
@@ -2,7 +2,7 @@ import { json, error, pino } from '$lib/server';
 import { filterGroup } from '$lib/schema/people/filters/filters';
 import { parse } from '$lib/schema/valibot';
 import { create } from '$lib/server/api/people/lists';
-const log = pino('API:/api/v1/people/[person_id]/filters/+server.ts');
+const log = pino(import.meta.url);
 import { generateUniqueString } from '$lib/utils/text/random';
 export async function PUT(event) {
 	try {

--- a/src/routes/(api)/api/v1/petitions/+server.ts
+++ b/src/routes/(api)/api/v1/petitions/+server.ts
@@ -2,7 +2,7 @@ import { json, pino, error } from '$lib/server';
 import * as api from '$lib/server/api/petitions/petitions';
 import * as schema from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 export async function GET(event) {
 	try {
 		const response = await api.list({

--- a/src/routes/(api)/api/v1/petitions/[petition_id]/+server.ts
+++ b/src/routes/(api)/api/v1/petitions/[petition_id]/+server.ts
@@ -2,7 +2,7 @@ import { json, error, pino } from '$lib/server';
 import * as api from '$lib/server/api/petitions/petitions';
 import * as schema from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
-const log = pino('API:/api/v1/petitions/[petition_id]/+server.ts');
+const log = pino(import.meta.url);
 
 export async function GET(event) {
 	try {

--- a/src/routes/(api)/api/v1/petitions/[petition_id]/signatures/+server.ts
+++ b/src/routes/(api)/api/v1/petitions/[petition_id]/signatures/+server.ts
@@ -4,7 +4,7 @@ import * as schema from '$lib/schema/petitions/signatures';
 import { parse } from '$lib/schema/valibot';
 import { read as readPetition } from '$lib/server/api/petitions/petitions';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
-const log = pino('API:/api/v1/events/+server.ts');
+const log = pino(import.meta.url);
 export async function GET(event) {
 	try {
 		const response = await api.listForPetition({

--- a/src/routes/(api)/worker/core/people/custom_fields/set_custom_field/+server.ts
+++ b/src/routes/(api)/worker/core/people/custom_fields/set_custom_field/+server.ts
@@ -1,7 +1,7 @@
 import { json, error, pino } from '$lib/server';
 import { setFieldValue } from '$lib/schema/people/custom_field_values';
 import { setCustomFieldValue } from '$lib/server/api/people/custom_field_values';
-const log = pino('/worker/core/people/custom_fields/set_custom_field');
+const log = pino(import.meta.url);
 
 import { parse } from '$lib/schema/valibot';
 

--- a/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
+++ b/src/routes/(api)/worker/cron/send_scheduled_emails/+server.ts
@@ -6,7 +6,7 @@ import {
 	update as updateEvent
 } from '$lib/server/api/events/events';
 import { unsafeListAllForEvent } from '$lib/server/api/events/attendees';
-const log = pino('/worker/utils/email/events/send_followup_email');
+const log = pino(import.meta.url);
 
 export async function POST(event) {
 	try {

--- a/src/routes/(api)/worker/events/registration/+server.ts
+++ b/src/routes/(api)/worker/events/registration/+server.ts
@@ -6,7 +6,7 @@ import updatePerson from '$lib/server/hooks/website/utils/update_person';
 import { create } from '$lib/server/api/events/attendees.js';
 import { read as readEvent } from '$lib/server/api/events/events';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
-const log = pino('/worker/events/registration');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/imports/people/[import_id]/+server.ts
+++ b/src/routes/(api)/worker/imports/people/[import_id]/+server.ts
@@ -7,7 +7,7 @@ import { create as createPerson } from '$lib/server/api/people/people';
 import { create as createSchema } from '$lib/schema/people/people';
 import { renderName } from '$lib/utils/text/names';
 import { v, parse } from '$lib/schema/valibot';
-const log = pino('/worker/imports/people');
+const log = pino(import.meta.url);
 
 export async function POST(event) {
 	try {

--- a/src/routes/(api)/worker/petitions/signature/+server.ts
+++ b/src/routes/(api)/worker/petitions/signature/+server.ts
@@ -7,7 +7,7 @@ import { create } from '$lib/server/api/petitions/signatures';
 import { read as readPetition } from '$lib/server/api/petitions/petitions';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
 
-const log = pino('/worker/events/registration');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/utils/email/events/send_cancellation_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/events/send_cancellation_email/+server.ts
@@ -3,7 +3,7 @@ import { triggerEventMessage, sendEventEmailMessage } from '$lib/schema/utils/em
 import { read as readPerson } from '$lib/server/api/people/people';
 import { read as readEvent } from '$lib/server/api/events/events';
 import { read as readMessage } from '$lib/server/api/communications/email/messages';
-const log = pino('/worker/utils/email/events/send_registration_email');
+const log = pino(import.meta.url);
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
 import { parse } from '$lib/schema/valibot';
 

--- a/src/routes/(api)/worker/utils/email/events/send_followup_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/events/send_followup_email/+server.ts
@@ -4,7 +4,7 @@ import { read as readPerson } from '$lib/server/api/people/people';
 import { read as readEvent } from '$lib/server/api/events/events';
 import { read as readMessage } from '$lib/server/api/communications/email/messages';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
-const log = pino('/worker/utils/email/events/send_followup_email');
+const log = pino(import.meta.url);
 import { parse } from '$lib/schema/valibot';
 
 export async function POST(event) {

--- a/src/routes/(api)/worker/utils/email/events/send_registration_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/events/send_registration_email/+server.ts
@@ -4,7 +4,7 @@ import { read as readPerson } from '$lib/server/api/people/people';
 import { read as readEvent } from '$lib/server/api/events/events';
 import { read as readMessage } from '$lib/server/api/communications/email/messages';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
-const log = pino('/worker/utils/email/events/send_registration_email');
+const log = pino(import.meta.url);
 
 import { parse } from '$lib/schema/valibot';
 

--- a/src/routes/(api)/worker/utils/email/events/send_reminder_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/events/send_reminder_email/+server.ts
@@ -4,7 +4,7 @@ import { read as readPerson } from '$lib/server/api/people/people';
 import { read as readEvent } from '$lib/server/api/events/events';
 import { read as readMessage } from '$lib/server/api/communications/email/messages';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';
-const log = pino('/worker/utils/email/events/send_reminder_email');
+const log = pino(import.meta.url);
 
 import { parse } from '$lib/schema/valibot';
 

--- a/src/routes/(api)/worker/utils/email/send_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/send_email/+server.ts
@@ -2,7 +2,7 @@ import { json, error, pino, BelcodaError } from '$lib/server';
 import { sendEmailMessage as sendEmailSchema } from '$lib/schema/utils/email';
 import sendEmail from '$lib/server/utils/email/send_email_postmark';
 import { markAsComplete } from '$lib/server/api/communications/email/sends.js';
-const log = pino('/worker/utils/email/send_email');
+const log = pino(import.meta.url);
 import { read } from '$lib/server/api/people/people';
 import { create as createSentEmail } from '$lib/server/api/communications/email/sent_emails';
 

--- a/src/routes/(api)/worker/utils/email/send_event_email/+server.ts
+++ b/src/routes/(api)/worker/utils/email/send_event_email/+server.ts
@@ -6,7 +6,7 @@ import {
 } from '$lib/schema/utils/email';
 import renderEmail from '$lib/server/utils/handlebars/render_email';
 import { read } from '$lib/server/api/communications/email/templates';
-const log = pino('/worker/utils/email/send_event_email');
+const log = pino(import.meta.url);
 import { randomUUID } from 'crypto';
 import { parse } from '$lib/schema/valibot';
 

--- a/src/routes/(api)/worker/utils/email/send_petition_autoresponse/+server.ts
+++ b/src/routes/(api)/worker/utils/email/send_petition_autoresponse/+server.ts
@@ -9,7 +9,7 @@ import { read as readPetition } from '$lib/server/api/petitions/petitions';
 import { read as readPerson } from '$lib/server/api/people/people';
 import { read as readTemplate } from '$lib/server/api/communications/email/templates';
 import { read as readMessage } from '$lib/server/api/communications/email/messages';
-const log = pino('/worker/utils/email/send_event_email');
+const log = pino(import.meta.url);
 import { randomUUID } from 'crypto';
 import { id, parse } from '$lib/schema/valibot';
 import { queue as queueInteraction } from '$lib/server/api/people/interactions';

--- a/src/routes/(api)/worker/utils/email/send_to_list/+server.ts
+++ b/src/routes/(api)/worker/utils/email/send_to_list/+server.ts
@@ -5,7 +5,7 @@ import {
 	type SendEmailMessage,
 	sendEmailToListSchema
 } from '$lib/schema/utils/email';
-const log = pino('/worker/utils/email/send_email');
+const log = pino(import.meta.url);
 import { getAllPersonIds } from '$lib/server/api/people/lists';
 import { markAsStarted } from '$lib/server/api/communications/email/sends';
 import { randomUUID } from 'crypto';

--- a/src/routes/(api)/worker/utils/people/match_sanction/+server.ts
+++ b/src/routes/(api)/worker/utils/people/match_sanction/+server.ts
@@ -6,7 +6,7 @@ import { read as readAdmin } from '$lib/server/api/core/admins';
 const exportSchema = v.object({
 	adminId: id
 });
-const log = pino('worker:utils/people/match_sanction');
+const log = pino(import.meta.url);
 import {
 	OFAC_API_KEY,
 	OFAC_DATA_SOURCES_ARRAY,

--- a/src/routes/(api)/worker/utils/people/record_interaction/+server.ts
+++ b/src/routes/(api)/worker/utils/people/record_interaction/+server.ts
@@ -1,6 +1,6 @@
 import { json, pino, error } from '$lib/server';
 import { create as createInteraction } from '$lib/server/api/people/interactions';
-const log = pino('WORKER:/utils/people/record_interaction');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/whatsapp/after_sent/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/after_sent/+server.ts
@@ -12,7 +12,7 @@ import { read as readTemplate } from '$lib/server/api/communications/whatsapp/te
 import { type Create } from '$lib/schema/communications/whatsapp/sent_whatsapp_messages';
 import type { InteractionTypeOutboundWhatsapp } from '$lib/schema/people/interactions';
 
-const log = pino('WORKER:/whatsapp/after_sent/+server.ts');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/whatsapp/after_sent_ycloud/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/after_sent_ycloud/+server.ts
@@ -12,7 +12,7 @@ import { read as readTemplate } from '$lib/server/api/communications/whatsapp/te
 import { type Create } from '$lib/schema/communications/whatsapp/sent_whatsapp_messages';
 import type { InteractionTypeOutboundWhatsapp } from '$lib/schema/people/interactions';
 
-const log = pino('WORKER:/whatsapp/after_sent_ycloud/+server.ts');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/whatsapp/send_message/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/send_message/+server.ts
@@ -12,7 +12,7 @@ import { _readSecretsUnsafe } from '$lib/server/api/core/instances';
 import { _updateWhatsappId, read } from '$lib/server/api/people/people';
 
 import type { AfterSend } from '$lib/schema/communications/whatsapp/worker/sending.js';
-const log = pino('/worker/whatsapp/send_message');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/whatsapp/webhook/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/webhook/+server.ts
@@ -1,7 +1,7 @@
 import { json, error, pino } from '$lib/server';
 import { parse } from '$lib/schema/valibot';
 import { webhook } from '$lib/schema/communications/whatsapp/webhooks/webhook';
-const log = pino('WORKER:/webhooks/whatsapp/+server.ts');
+const log = pino(import.meta.url);
 
 import { create as createReceivedMessage } from '$lib/server/api/communications/whatsapp/received_messages';
 import { create as createInteraction } from '$lib/server/api/people/interactions';

--- a/src/routes/(api)/worker/whatsapp/webhook/ycloud/incoming/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/webhook/ycloud/incoming/+server.ts
@@ -1,7 +1,7 @@
 import { json, error, pino } from '$lib/server';
 import { parse } from '$lib/schema/valibot';
 import { yCloudWebhook } from '$lib/schema/communications/whatsapp/webhooks/ycloud';
-const log = pino('WORKER:/webhooks/whatsapp/+server.ts');
+const log = pino(import.meta.url);
 
 import { create as createReceivedMessage } from '$lib/server/api/communications/whatsapp/received_messages';
 import { create as createInteraction } from '$lib/server/api/people/interactions';

--- a/src/routes/(api)/worker/whatsapp/webhook/ycloud/update/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/webhook/ycloud/update/+server.ts
@@ -1,7 +1,7 @@
 import { json, error, pino, BelcodaError } from '$lib/server';
 import { parse } from '$lib/schema/valibot';
 import { yCloudWebhook } from '$lib/schema/communications/whatsapp/webhooks/ycloud';
-const log = pino('WORKER:/webhooks/whatsapp/+server.ts');
+const log = pino(import.meta.url);
 
 import { create as createReceivedMessage } from '$lib/server/api/communications/whatsapp/received_messages';
 import { create as createInteraction } from '$lib/server/api/people/interactions';

--- a/src/routes/(api)/worker/whatsapp/whapi/check_phone_number/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/whapi/check_phone_number/+server.ts
@@ -3,7 +3,7 @@ import { whatsappNumberForVerification } from '$lib/schema/people/channels/chann
 import { parse } from '$lib/schema/valibot';
 import { checkContact } from '$lib/server/utils/whapi/contacts';
 import { read, update } from '$lib/server/api/people/people';
-const log = pino('worker:/whatsapp/whapi/check_phone_number');
+const log = pino(import.meta.url);
 export async function POST(event) {
 	try {
 		const body = await event.request.json();

--- a/src/routes/(api)/worker/whatsapp/whapi/webhook/+server.ts
+++ b/src/routes/(api)/worker/whatsapp/whapi/webhook/+server.ts
@@ -11,7 +11,7 @@ import convertWebhookMessage from './convertMessages';
 import { create } from '$lib/server/api/communications/whatsapp/received_whatsapp_group_messages';
 import { type Create } from '$lib/schema/communications/whatsapp/received_whatsapp_group_messages';
 
-const log = pino('worker:whatsapp/whapi/webhook');
+const log = pino(import.meta.url);
 
 export async function POST(event) {
 	try {

--- a/src/routes/(app)/events/[event_id]/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/+page.server.ts
@@ -13,7 +13,7 @@ import {
 import { read } from '$lib/schema/events/events';
 import { list as listForEvent, update as updateAttendee } from '$lib/schema/events/attendees';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);

--- a/src/routes/(app)/events/[event_id]/edit/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/edit/+page.server.ts
@@ -12,7 +12,7 @@ import {
 
 import { update, read } from '$lib/schema/events/events';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);
 	if (!response.ok) return loadError(response);

--- a/src/routes/(app)/events/[event_id]/edit/notifications/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/edit/notifications/+page.server.ts
@@ -14,7 +14,7 @@ import {
 import { read, update } from '$lib/schema/events/events';
 import { update as updateEmailMessage } from '$lib/schema/communications/email/messages';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);

--- a/src/routes/(app)/events/[event_id]/preview/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/preview/+page.server.ts
@@ -16,7 +16,7 @@ import { redirect } from '@sveltejs/kit';
 import { update, read } from '$lib/schema/events/events';
 import { list as listForEvent } from '$lib/schema/events/attendees';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/preview/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);
 	if (!response.ok) return loadError(response);

--- a/src/routes/(app)/events/[event_id]/print/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/print/+page.server.ts
@@ -14,7 +14,7 @@ import { read } from '$lib/schema/events/events';
 import { list as listForEvent, update as updateAttendee } from '$lib/schema/events/attendees';
 import { unsafeListAllForEvent } from '$lib/server/api/events/attendees.js';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/[event_id]/print/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/events/${event.params.event_id}`);

--- a/src/routes/(app)/events/[event_id]/register/+page.server.ts
+++ b/src/routes/(app)/events/[event_id]/register/+page.server.ts
@@ -17,7 +17,7 @@ import { parse } from '$lib/schema/valibot';
 
 import { read } from '$lib/schema/events/events';
 
-const log = pino('(app)/events/[event_id]/register/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	//event.url.searchParams.append('isRegisteredForEvent', event.params.event_id);
 	const url = new URL(event.url);

--- a/src/routes/(app)/events/new/+page.server.ts
+++ b/src/routes/(app)/events/new/+page.server.ts
@@ -11,7 +11,7 @@ import {
 
 import { create, read } from '$lib/schema/events/events';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(
 		{ ...event.locals.instance.settings.events.default_event_info_settings },

--- a/src/routes/(app)/petitions/[petition_id]/+page.server.ts
+++ b/src/routes/(app)/petitions/[petition_id]/+page.server.ts
@@ -3,7 +3,7 @@ import { pino, loadError } from '$lib/server';
 import { read } from '$lib/schema/petitions/petitions';
 import { list as listForPetition } from '$lib/schema/petitions/signatures';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/petitions/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/petitions/${event.params.petition_id}`);
 	if (!response.ok) return loadError(response);

--- a/src/routes/(app)/petitions/[petition_id]/edit/+page.server.ts
+++ b/src/routes/(app)/petitions/[petition_id]/edit/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, valibot, formAction, redirect, pino, loadError } from '$
 
 import { update, read } from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/petitions/[petition_id]/petition/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/petitions/${event.params.petition_id}`);
 	if (!response.ok) return loadError(response);

--- a/src/routes/(app)/petitions/[petition_id]/edit/advanced/+page.server.ts
+++ b/src/routes/(app)/petitions/[petition_id]/edit/advanced/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, valibot, pino, loadError } from '$lib/server';
 
 import { update, read } from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/petitions/[petition_id]/petition/edit/advanced/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/petitions/${event.params.petition_id}`);

--- a/src/routes/(app)/petitions/[petition_id]/edit/notifications/+page.server.ts
+++ b/src/routes/(app)/petitions/[petition_id]/edit/notifications/+page.server.ts
@@ -14,7 +14,7 @@ import {
 import { read, update } from '$lib/schema/petitions/petitions';
 import { update as updateEmailMessage } from '$lib/schema/communications/email/messages';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/petitions/[petition_id]/edit/notifications/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/petitions/${event.params.petition_id}`);

--- a/src/routes/(app)/petitions/[petition_id]/preview/+page.server.ts
+++ b/src/routes/(app)/petitions/[petition_id]/preview/+page.server.ts
@@ -15,7 +15,7 @@ import { PUBLIC_HOST } from '$env/static/public';
 import { update, read } from '$lib/schema/petitions/petitions';
 import { list as listForEvent } from '$lib/schema/petitions/signatures';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/preview/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/petitions/${event.params.petition_id}`);

--- a/src/routes/(app)/petitions/new/+page.server.ts
+++ b/src/routes/(app)/petitions/new/+page.server.ts
@@ -12,7 +12,7 @@ import {
 
 import { create, read } from '$lib/schema/petitions/petitions';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(
 		{ ...event.locals.instance.settings.events.default_event_info_settings },

--- a/src/routes/(app)/settings/tags/new/+page.server.ts
+++ b/src/routes/(app)/settings/tags/new/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, valibot, redirect, pino, formAction } from '$lib/server'
 
 import { create, read } from '$lib/schema/core/tags';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/settings/tags/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(valibot(create));
 	return { form };

--- a/src/routes/(app)/settings/website/blocks/[block_id]/+page.server.ts
+++ b/src/routes/(app)/settings/website/blocks/[block_id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 import { update, read } from '$lib/schema/website/blocks';
 import { v } from '$lib/schema/valibot';
 
-const log = pino('(app)/settings/website/blocks/[block_id]/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/website/blocks/${event.params.block_id}`);

--- a/src/routes/(app)/settings/website/templates/[template_id]/+page.server.ts
+++ b/src/routes/(app)/settings/website/templates/[template_id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 import { update, read } from '$lib/schema/website/templates';
 import { v } from '$lib/schema/valibot';
 
-const log = pino('(app)/settings/website/templates/[template_id]/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(`/api/v1/website/templates/${event.params.template_id}`);

--- a/src/routes/(app)/website/pages/[page_id]/+page.server.ts
+++ b/src/routes/(app)/website/pages/[page_id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 
 import { update, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(
 		`/api/v1/website/content_types/${event.locals.instance.settings.website.pages_content_type_id}/content/${event.params.page_id}`

--- a/src/routes/(app)/website/pages/[page_id]/advanced/+page.server.ts
+++ b/src/routes/(app)/website/pages/[page_id]/advanced/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, valibot, pino, loadError } from '$lib/server';
 
 import { update, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/website/pages/[page_id]/advanced/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(

--- a/src/routes/(app)/website/pages/[page_id]/preview/+page.server.ts
+++ b/src/routes/(app)/website/pages/[page_id]/preview/+page.server.ts
@@ -4,7 +4,7 @@ import { redirect } from '@sveltejs/kit';
 import { PUBLIC_HOST } from '$env/static/public';
 import { read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/pages/[page_id]/preview/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(
 		`/api/v1/website/content_types/${event.locals.instance.settings.website.pages_content_type_id}/content/${event.params.page_id}`

--- a/src/routes/(app)/website/pages/new/+page.server.ts
+++ b/src/routes/(app)/website/pages/new/+page.server.ts
@@ -11,7 +11,7 @@ import {
 
 import { create, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/website/pages/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(valibot(create));
 	return { form };

--- a/src/routes/(app)/website/posts/[post_id]/+page.server.ts
+++ b/src/routes/(app)/website/posts/[post_id]/+page.server.ts
@@ -12,7 +12,7 @@ import {
 
 import { update, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(
 		`/api/v1/website/content_types/${event.locals.instance.settings.website.posts_content_type_id}/content/${event.params.post_id}`

--- a/src/routes/(app)/website/posts/[post_id]/advanced/+page.server.ts
+++ b/src/routes/(app)/website/posts/[post_id]/advanced/+page.server.ts
@@ -2,7 +2,7 @@ import { superValidate, valibot, pino, loadError } from '$lib/server';
 
 import { update, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/website/posts/[post_id]/advanced/+page.server.ts');
+const log = pino(import.meta.url);
 
 export async function load(event) {
 	const response = await event.fetch(

--- a/src/routes/(app)/website/posts/[post_id]/preview/+page.server.ts
+++ b/src/routes/(app)/website/posts/[post_id]/preview/+page.server.ts
@@ -4,7 +4,7 @@ import { redirect } from '@sveltejs/kit';
 import { PUBLIC_HOST } from '$env/static/public';
 import { read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/events/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const response = await event.fetch(
 		`/api/v1/website/content_types/${event.locals.instance.settings.website.posts_content_type_id}/content/${event.params.post_id}`

--- a/src/routes/(app)/website/posts/new/+page.server.ts
+++ b/src/routes/(app)/website/posts/new/+page.server.ts
@@ -11,7 +11,7 @@ import {
 
 import { create, read } from '$lib/schema/website/content';
 import { parse } from '$lib/schema/valibot';
-const log = pino('(app)/website/pages/new/+page.server.ts');
+const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(valibot(create));
 	return { form };

--- a/src/routes/(preview)/preview/email/[email_id]/+page.server.ts
+++ b/src/routes/(preview)/preview/email/[email_id]/+page.server.ts
@@ -6,7 +6,7 @@ import { read as readEvent } from '$lib/schema/events/events';
 import { randomUUID } from 'crypto';
 import { parse } from '$lib/schema/valibot';
 
-const log = pino('(preview)/preview/email/[email_id]/+page.server.ts');
+const log = pino(import.meta.url);
 export const load = async (event) => {
 	const messageResponse = await event.fetch(
 		`/api/v1/communications/email/messages/${event.params.email_id}`


### PR DESCRIPTION
This is a fairly simple change to send production logs to Sentry, using a transport library for Sentry as a plugin for our logging library, Pino. 

Additionally, I updated two things with Pino to improve developer experience and performance: 

1. Each file no longer initializes an entire new instance of the Pino logger, which could cause a memory leak as a new EventEmitter is created on each initialization and may not be disposed of properly. Instead, now, one single logger instance is created for the app, and each file instead has a child logger, which should improve performance. 
2. Instead of initializing logger instances with a manually provided file path/name or identifier, we can just use `import.meta.url` to generate the full file path. This will be better for linking to the file in the IDE console for development, as well as making our life easier when writing the code to initialize a new logger instance. It will also avoid human errors in providing the manual identifier. 

Because of point 2, I went ahead and updated every existing initialization of the logger in the app to use `import.meta.url` from their existing manual file identifier. This means that the commit is large, affecting a lot of files. However, all the changes are identical and only affect a single line initializing the logger. 