### PR TITLE
Person activity page changes

### DIFF
--- a/src/lib/server/api/people/interactions.ts
+++ b/src/lib/server/api/people/interactions.ts
@@ -36,12 +36,12 @@ export async function list({
 	type?: 'communications' | 'activity' | null;
 }): Promise<List> {
 	const { filtered, where, options } = filterQuery(url);
-	if (!filtered) {
-		const cached = await redis.get(redisString(instanceId, personId, type));
-		if (cached) {
-			return parse(listSchema, cached);
-		}
-	}
+	// if (!filtered) {
+	// 	const cached = await redis.get(redisString(instanceId, personId, type));
+	// 	if (cached) {
+	// 		return parse(listSchema, cached);
+	// 	}
+	// }
 	//either it's activity, or conditions or simply just not null...
 	const typeConditions = filterInteractions(url);
 	const interactions = await db

--- a/src/routes/(app)/people/[person_id]/+page.server.ts
+++ b/src/routes/(app)/people/[person_id]/+page.server.ts
@@ -15,9 +15,17 @@ export async function load(event) {
 		? parse(formattedPhoneNumber, parsed.phone_number)
 		: null;
 
-	const interactions = await event.fetch(
-		filter(`/api/v1/people/${event.params.person_id}/interactions?display=activity`, event.url)
+	const interactionsUrl = new URL(
+		`/api/v1/people/${event.params.person_id}/interactions`,
+		event.url
 	);
+	const page = event.url.searchParams.get('page');
+	if (page) {
+		interactionsUrl.searchParams.set('page', page);
+	}
+	interactionsUrl.searchParams.set('display', 'activity');
+
+	const interactions = await event.fetch(filter(interactionsUrl.toString(), event.url));
 	if (!result.ok) loadError(interactions);
 	const interactionsBody = await interactions.json();
 	const parsedInteractions = parse(listInteractions, interactionsBody);

--- a/src/routes/(app)/people/[person_id]/LogActivity.svelte
+++ b/src/routes/(app)/people/[person_id]/LogActivity.svelte
@@ -108,6 +108,9 @@
 	}
 </script>
 
+<div
+	class={`border rounded-sm shadow-sm p-3 ${selected === 'notes' ? 'bg-yellow-100' : selected === 'outbound_whatsapp' ? 'bg-blue-100' : 'bg-white'} relative`}
+>
 	{#if isPosting}
 		<div
 			class="absolute inset-0 bg-white bg-opacity-50 flex items-center justify-center z-10 rounded-sm"

--- a/src/routes/(app)/people/[person_id]/LogActivity.svelte
+++ b/src/routes/(app)/people/[person_id]/LogActivity.svelte
@@ -10,6 +10,7 @@
 		| 'outbound_whatsapp';
 	import Button from '$lib/comps/ui/button/button.svelte';
 	import sendWhatsappMessage from '$lib/comps/widgets/interactions/sendWhatsappMessage.js';
+	import LoaderCircle from 'lucide-svelte/icons/loader-circle';
 
 	const types: { value: InteractionType; label: string }[] = [
 		{ value: 'notes', label: $page.data.t.people.interactions.create_types.notes() },
@@ -27,6 +28,7 @@
 	import { getFlash } from 'sveltekit-flash-message';
 	let flash = getFlash(page);
 	let notes: string | undefined = $state(undefined);
+	let isPosting: boolean = $state(false);
 
 	let activeConversation: boolean = $state(false);
 	let activeConversationLoading: boolean = $state(false);
@@ -68,6 +70,8 @@
 	async function logInteraction(e?: SubmitEvent) {
 		try {
 			if (e) e.preventDefault();
+			isPosting = true;
+
 			if (selected === 'outbound_whatsapp' && notes) {
 				await sendWhatsappMessage(notes, personId, $page.data.admin.id);
 				onLogged();
@@ -99,12 +103,20 @@
 				$flash = { type: 'error', message: $page.data.t.errors.generic() };
 			}
 		} finally {
-			notes = undefined;
+			isPosting = false;
 		}
 	}
 </script>
 
-<div class="bg-white border rounded-sm shadow-sm p-3">
+	{#if isPosting}
+		<div
+			class="absolute inset-0 bg-white bg-opacity-50 flex items-center justify-center z-10 rounded-sm"
+		>
+			<div class="animate-spin text-primary">
+				<LoaderCircle size={24} />
+			</div>
+		</div>
+	{/if}
 	<form onsubmit={logInteraction}>
 		<div class="grid items-baseline gap-3 grid-cols-1 md:grid-cols-3 lg:grid-cols-4">
 			{@render selectType()}
@@ -137,8 +149,21 @@
 
 		<div class="sm:flex sm:justify-end mt-3">
 			{#if selected !== 'outbound_whatsapp' || activeConversation}
-				<Button class="w-full sm:w-auto" type="submit" variant="default" size="sm">
-					{$page.data.t.forms.buttons.post()}
+				<Button
+					class="w-full sm:w-auto"
+					type="submit"
+					variant="default"
+					size="sm"
+					disabled={isPosting}
+				>
+					{#if isPosting}
+						<div class="flex items-center gap-2">
+							<span class="animate-spin"><LoaderCircle size={16} /></span>
+							<span>{$page.data.t.common.status.loading()}</span>
+						</div>
+					{:else}
+						{$page.data.t.forms.buttons.post()}
+					{/if}
 				</Button>
 			{/if}
 		</div>

--- a/src/routes/(app)/people/[person_id]/activity_feed/ActivityItem.svelte
+++ b/src/routes/(app)/people/[person_id]/activity_feed/ActivityItem.svelte
@@ -11,12 +11,20 @@
 		person: ReadPerson;
 		children?: Snippet;
 		button?: Snippet;
+		class?: string;
 	};
-	const { interaction, activityMessage, displayUserAvatar, person, children, button }: Props =
-		$props();
+	const {
+		interaction,
+		activityMessage,
+		displayUserAvatar,
+		person,
+		children,
+		button,
+		class: className
+	}: Props = $props();
 </script>
 
-<div class="bg-white rounded-sm shadow-sm border pt-2 pb-3 px-4">
+<div class={`bg-white rounded-sm shadow-sm border pt-2 pb-3 px-4 ${className}`}>
 	<div class="flex items-center gap-4 justify-between">
 		<div class="flex items-center gap-4">
 			<div>

--- a/src/routes/(app)/people/[person_id]/activity_feed/notes/Notes.svelte
+++ b/src/routes/(app)/people/[person_id]/activity_feed/notes/Notes.svelte
@@ -27,6 +27,7 @@
 		activityMessage={$page.data.t.people.interactions.interactionMessage.notes(
 			interaction.admin.full_name
 		)}
+		class="bg-yellow-100"
 	>
 		{#if edit}
 			<div class="mt-2">
@@ -46,7 +47,7 @@
 				</div>
 			</div>
 		{:else}
-			<div class="mt-2 text-sm text-muted-foreground">
+			<div class="mt-2 text-sm text-muted-foreground bg-yellow-100">
 				{@html sanitizeHTML(addLineBreaks(interaction.details.notes))}
 			</div>
 			{#if interaction.details.edit_history.length > 0}

--- a/src/routes/(app)/people/[person_id]/activity_feed/notes/Notes.svelte
+++ b/src/routes/(app)/people/[person_id]/activity_feed/notes/Notes.svelte
@@ -11,6 +11,8 @@
 	type Props = {
 		interaction: List['items'][number];
 		person: ReadPerson;
+		activityMessage?: string;
+		children?: any;
 	};
 	let { interaction, person }: Props = $props();
 	let edit: boolean = $state(false);


### PR DESCRIPTION
This adds some visual changes to the person activity to makes notes more visually distinct from other communications. The idea here is that as a user, you don't want to write a note about a person and press Enter only to realize you've sent a whatsapp message to the person.

![image](https://github.com/user-attachments/assets/866c178b-ea91-4d35-bf24-9754426f9c79)

This PR also fixes the pagination issue in the person activity page. The issue was caused by the fact that we were re-writing the URL but forgetting to attach the search params that were sent in the original URL.

I have also commented out the section that fetches interactions from the cache coz this was causing some weird behaviour where certain interactions would not show up unless some operation updates the cache with new entries first. I've commented out the code rather than removed it because there's a chance we might figure out how to use the cache better and want to go back to it.