### PR TITLE
Update menu links to be easier to click

### DIFF
--- a/src/lib/comps/nav/desktop/main-nav.svelte
+++ b/src/lib/comps/nav/desktop/main-nav.svelte
@@ -13,12 +13,12 @@
 			<Menubar.Trigger>{menu_items[key].title()}</Menubar.Trigger>
 			<Menubar.Content>
 				{#each menu_items[key].children as item}
-					<Menubar.Item>
-						<a href={item.href({ ...$page.params })} class="flex items-center gap-2">
+					<a href={item.href({ ...$page.params })}>
+						<Menubar.Item class="flex items-center gap-2 cursor-pointer">
 							<svelte:component this={item.icon} class="h-4" strokeWidth={2} />
 							{item.title()}
-						</a>
-					</Menubar.Item>
+						</Menubar.Item>
+					</a>
 				{/each}
 			</Menubar.Content>
 		</Menubar.Menu>

--- a/src/lib/comps/nav/mobile/main-nav.svelte
+++ b/src/lib/comps/nav/mobile/main-nav.svelte
@@ -18,18 +18,17 @@
 					</span>
 					<ul class="flex flex-col gap-0 pl-6 mt-2">
 						{#each menuItems[itemKey].children as child}
-							<li>
-								<a
-									href={child.href({ ...$page.params })}
-									onclick={() => (open = false)}
-									class={cn(
-										buttonVariants({ variant: 'ghost', size: 'sm' }),
-										$page.url.pathname === child.href({ ...$page.params })
-											? 'bg-muted hover:bg-muted'
-											: 'hover:bg-muted',
-										'justify-start w-full flex gap-2 items-center'
-									)}
-								>
+							<a
+								href={child.href({ ...$page.params })}
+								onclick={() => (open = false)}
+								class={cn(
+									buttonVariants({ variant: 'ghost', size: 'sm' }),
+									$page.url.pathname === child.href({ ...$page.params })
+										? 'bg-muted hover:bg-muted'
+										: 'hover:bg-muted'
+								)}
+							>
+								<li class="justify-start w-full flex gap-2 items-center">
 									<div>
 										<svelte:component
 											this={child.icon}
@@ -39,8 +38,8 @@
 										/>
 									</div>
 									{child.title()}
-								</a>
-							</li>
+								</li>
+							</a>
 						{/each}
 					</ul>
 				</li>


### PR DESCRIPTION
This is a very small PR to move the `<a>` tags for menu links to wrap the whole link button/`<li>` instead of only wrapping the content. This will make it easier to click the link because you can click anywhere on the button/navigation element, rather than having to click the text in order for the link to work. 

This something I had encountered a fair bit when using the app, so it's a small fix for a small QOL improvement. 