### PR TITLE
Set pino log level at instance initialization

### DIFF
--- a/src/lib/server/utils/logs/pino.ts
+++ b/src/lib/server/utils/logs/pino.ts
@@ -6,70 +6,29 @@ import {
 	GRAFANA_SERVICE_ACCOUNT_TOKEN
 } from '$env/static/private';
 import { PUBLIC_SENTRY_DSN } from '$env/static/public';
-import type { LokiOptions } from 'pino-loki';
 
 import { dev } from '$app/environment';
 
-const lokiTransport = pino_transport<LokiOptions>({
-	target: 'pino-loki',
-	level: 'debug',
-	options: {
-		batching: true,
-		interval: 5,
-		host: GRAFANA_URL,
-		basicAuth: {
-			username: GRAFANA_SERVICE_ACCOUNT_NAME,
-			password: GRAFANA_SERVICE_ACCOUNT_TOKEN
-		}
-	}
-});
-
-const defaultTransport = pino_transport({
-	target: 'pino/file',
-	level: LOG_LEVEL ?? 'debug',
-	options: { destination: 1 } // this writes to STDOUT
-});
-
-const productionTransports = pino_transport({
-	targets: [
-		{
-			target: 'pino-sentry-transport',
-			options: {
-				sentry: {
-					dsn: PUBLIC_SENTRY_DSN, // sentry dsn
-					environment: dev ? 'development' : 'production'
-					// additional options for sentry
-				},
-				withLogRecord: true, // default false - send the entire log record to sentry as a context.(FYI if its more then 8Kb Sentry will throw an error)
-				tags: ['level'], // sentry tags to add to the event, uses lodash.get to get the value from the log record
-				context: ['hostname'], // sentry context to add to the event, uses lodash.get to get the value from the log record,
-				minLevel: 40 // which level to send to sentry
-			}
-		},
-		defaultTransport
-	]
-});
-
-const developmentTransports = pino_transport({
-	targets: [defaultTransport, lokiTransport]
-});
-
 const logger = dev
 	? pino_instance(
+			{ level: LOG_LEVEL || 'debug' },
 			pino_transport({
 				targets: [
 					{
 						target: 'pino/file',
+						level: LOG_LEVEL || 'debug',
 						options: { destination: 1 } // this writes to STDOUT
 					}
 				]
 			})
 		)
 	: pino_instance(
+			{ level: LOG_LEVEL || 'debug' },
 			pino_transport({
 				targets: [
 					{
 						target: 'pino/file',
+						level: LOG_LEVEL || 'debug',
 						options: { destination: 1 } // this writes to STDOUT
 					},
 					{
@@ -88,7 +47,7 @@ const logger = dev
 					},
 					{
 						target: 'pino-loki',
-						level: 'debug',
+						level: LOG_LEVEL || 'debug',
 						options: {
 							batching: true,
 							interval: 5,


### PR DESCRIPTION
Pino allows log levels to be set in the transports, but appears to require that levels are set in the instance initialization as well as the transports. 

Unfortunately, none of the documentation that I saw made this clear, and all documentation that I saw relating to the `Pino.Transport` object appears to only set the level in the transport initialization. 

This fix sets it at the pino instance initialization for both production and dev instances. 