### PR TITLE
Allocate more memory to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY ./.env.production ./.env
 COPY ./project.inlang ./project.inlang
 RUN npm install
 COPY . .
-ENV NODE_OPTIONS=--max_old_space_size=1800
+ENV NODE_OPTIONS=--max_old_space_size=4096
 RUN npm run build
 
 FROM node:lts-alpine AS production


### PR DESCRIPTION
Building takes too long and is timing out in Github Actions. This is a way to add more memory to the build job, and hopefully reduce timeouts. In the future, we should explore building using Github larger runners instead.