### PR TITLE
Add whatsapp links to event and petition pages

### DIFF
--- a/src/lib/server/templates/website/blocks/events/event_info.hbs
+++ b/src/lib/server/templates/website/blocks/events/event_info.hbs
@@ -17,3 +17,10 @@
   </div>
 </div>
 {{/if}}
+
+<div class="flex items-center gap-2 mt-4">
+  <div class="font-bold">{{icon "message-circle"}}</div>
+  <div class="">
+    <a href="{{whatsapp_registration_url instance event}}" target="_blank" class="text-primary hover:underline">Register via WhatsApp</a>
+  </div>
+</div>

--- a/src/lib/server/templates/website/blocks/petitions/petition_info.hbs
+++ b/src/lib/server/templates/website/blocks/petitions/petition_info.hbs
@@ -4,3 +4,10 @@
 {{#if petition.petition_text}}
 <p class="italic text-lg mt-3">{{{petition.petition_text}}}</p>
 {{/if}}
+
+<div class="flex items-center gap-2 mt-4">
+  <div class="font-bold">{{icon "message-circle"}}</div>
+  <div class="">
+    <a href="{{whatsapp_registration_url instance petition}}" target="_blank" class="text-primary hover:underline">Sign via WhatsApp</a>
+  </div>
+</div>


### PR DESCRIPTION
This PR adds links to the event and petition pages that users can use to signup to events or sign petititions. These were previously implemented using migrations to update the templates in the database. We moved to hard-coded templates but didn't move the links at the time.