### PR TITLE
Allow non-strict country code parsing of phone numbers

### DIFF
--- a/src/lib/server/hooks/website/utils/update_person.ts
+++ b/src/lib/server/hooks/website/utils/update_person.ts
@@ -54,6 +54,7 @@ export default async function ({
 		phone_number: signupInfo.phone_number,
 		whatsapp_id: signupInfo.phone_number,
 		country: country,
+		strict: false, //this is to allow international signups. Eventually this code needs to be refactored.
 		subscribed: signupInfo.opt_in
 	});
 


### PR DESCRIPTION
**Allow non-strict parsing of phone numbers on event and petition signup via the website**

Previously it was strict (ie: if the phone number couldn't be parsed as a valid phone number in the same country as the instance, it would fail the signup.

For an international group like Roots, this is a big problem. This is a good fix for now, but we will have to update the event signup logic later to truly meet Roots needs (eg: support asking different questions, collecting additional info, etc)

For now, this is a simple fix which I have tested in development and appears to work well to allow any people to sign up regardless of phone number.