### PR TITLE
Patch/remove old localization strings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -458,6 +458,7 @@
 	"just_giant_pony_urge": "Custom CSS",
 	"aqua_north_fox_grace": "Custom Javascript",
 	"teary_sharp_starfish_honor": "Custom CSS",
+	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Custom Javascript",
 	"sharp_sea_anteater_walk": "Upload or select feature image",
 	"still_zany_warbler_savor": "Upload or select feature image",
@@ -577,5 +578,9 @@
 	"wide_male_parrot_enrich": "You can't delete yourself. If you wish to delete the currently signed in admin account, please ask another admin to delete it.",
 	"patient_muddy_llama_work": "Unable to delete default instance administrator record",
 	"low_petty_martin_dazzle": "Unable to delete only admin in organization. Please contact support if you wish to delete the entire organization account.",
-	"ornate_real_swallow_honor": "Error deleting admin record. Record was not deleted."
+	"ornate_real_swallow_honor": "Error deleting admin record. Record was not deleted.",
+	"happy_inclusive_hyena_cuddle": "Error deleting record. Please try again",
+	"elegant_whole_mayfly_zap": "Admin was deleted successfully",
+	"wide_major_pig_swim": "Delete",
+	"moving_acidic_crow_imagine": "Are you sure you want to delete this record. This action cannot be undone?"
 }

--- a/messages/en.json
+++ b/messages/en.json
@@ -458,7 +458,6 @@
 	"just_giant_pony_urge": "Custom CSS",
 	"aqua_north_fox_grace": "Custom Javascript",
 	"teary_sharp_starfish_honor": "Custom CSS",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Custom Javascript",
 	"sharp_sea_anteater_walk": "Upload or select feature image",
 	"still_zany_warbler_savor": "Upload or select feature image",

--- a/messages/en.json
+++ b/messages/en.json
@@ -458,7 +458,6 @@
 	"just_giant_pony_urge": "Custom CSS",
 	"aqua_north_fox_grace": "Custom Javascript",
 	"teary_sharp_starfish_honor": "Custom CSS",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Custom Javascript",
 	"sharp_sea_anteater_walk": "Upload or select feature image",
 	"still_zany_warbler_savor": "Upload or select feature image",
@@ -575,7 +574,7 @@
 	"clean_sea_thrush_dial": "Female",
 	"teal_maroon_mantis_scoop": "Other",
 	"awake_topical_rook_jolt": "Not specified",
- 	"wide_male_parrot_enrich": "You can't delete yourself. If you wish to delete the currently signed in admin account, please ask another admin to delete it.",
+	"wide_male_parrot_enrich": "You can't delete yourself. If you wish to delete the currently signed in admin account, please ask another admin to delete it.",
 	"patient_muddy_llama_work": "Unable to delete default instance administrator record",
 	"low_petty_martin_dazzle": "Unable to delete only admin in organization. Please contact support if you wish to delete the entire organization account.",
 	"ornate_real_swallow_honor": "Error deleting admin record. Record was not deleted."

--- a/messages/es.json
+++ b/messages/es.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "CSS personalizado",
 	"aqua_north_fox_grace": "Javascript personalizado",
 	"teary_sharp_starfish_honor": "CSS personalizado",
+	"misty_awful_kitten_walk": "datos.t.forms.campos.código_personalizado.custom_js.etiqueta()",
 	"plain_real_clownfish_flow": "Javascript personalizado",
 	"sharp_sea_anteater_walk": "Subir o seleccionar imagen destacada",
 	"still_zany_warbler_savor": "Subir o seleccionar imagen destacada",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "No puedes eliminarte a ti mismo. Si deseas eliminar la cuenta de administrador que ha iniciado sesión, pídele a otro administrador que la elimine.",
 	"patient_muddy_llama_work": "No se puede eliminar el registro del administrador de instancia predeterminado",
 	"low_petty_martin_dazzle": "No se puede eliminar solo al administrador de la organización. Contacte con el soporte si desea eliminar toda la cuenta de la organización.",
-	"ornate_real_swallow_honor": "Error al eliminar el registro de administrador. El registro no se eliminó."
+	"ornate_real_swallow_honor": "Error al eliminar el registro de administrador. El registro no se eliminó.",
+	"happy_inclusive_hyena_cuddle": "Error al eliminar el registro. Inténtalo de nuevo.",
+	"elegant_whole_mayfly_zap": "El administrador fue eliminado exitosamente",
+	"wide_major_pig_swim": "Borrar",
+	"moving_acidic_crow_imagine": "¿Está seguro de que desea eliminar este registro? Esta acción no se puede deshacer."
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS personalizado",
 	"aqua_north_fox_grace": "Javascript personalizado",
 	"teary_sharp_starfish_honor": "CSS personalizado",
-	"misty_awful_kitten_walk": "datos.t.forms.campos.código_personalizado.custom_js.etiqueta()",
 	"plain_real_clownfish_flow": "Javascript personalizado",
 	"sharp_sea_anteater_walk": "Subir o seleccionar imagen destacada",
 	"still_zany_warbler_savor": "Subir o seleccionar imagen destacada",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "Femenino",
 	"teal_maroon_mantis_scoop": "Otro",
 	"awake_topical_rook_jolt": "No especificado",
-  "wide_male_parrot_enrich": "No puedes eliminarte a ti mismo. Si deseas eliminar la cuenta de administrador que ha iniciado sesión, pídele a otro administrador que la elimine.",
+	"wide_male_parrot_enrich": "No puedes eliminarte a ti mismo. Si deseas eliminar la cuenta de administrador que ha iniciado sesión, pídele a otro administrador que la elimine.",
 	"patient_muddy_llama_work": "No se puede eliminar el registro del administrador de instancia predeterminado",
 	"low_petty_martin_dazzle": "No se puede eliminar solo al administrador de la organización. Contacte con el soporte si desea eliminar toda la cuenta de la organización.",
 	"ornate_real_swallow_honor": "Error al eliminar el registro de administrador. El registro no se eliminó."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS personnalisé",
 	"aqua_north_fox_grace": "Javascript personnalisé",
 	"teary_sharp_starfish_honor": "CSS personnalisé",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript personnalisé",
 	"sharp_sea_anteater_walk": "Télécharger ou sélectionner l'image principale",
 	"still_zany_warbler_savor": "Télécharger ou sélectionner l'image principale",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS personnalisé",
 	"aqua_north_fox_grace": "Javascript personnalisé",
 	"teary_sharp_starfish_honor": "CSS personnalisé",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript personnalisé",
 	"sharp_sea_anteater_walk": "Télécharger ou sélectionner l'image principale",
 	"still_zany_warbler_savor": "Télécharger ou sélectionner l'image principale",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "Femelle",
 	"teal_maroon_mantis_scoop": "Autre",
 	"awake_topical_rook_jolt": "Non spécifié",
-  "wide_male_parrot_enrich": "Vous ne pouvez pas vous supprimer vous-même. Si vous souhaitez supprimer le compte administrateur actuellement connecté, veuillez demander à un autre administrateur de le faire.",
+	"wide_male_parrot_enrich": "Vous ne pouvez pas vous supprimer vous-même. Si vous souhaitez supprimer le compte administrateur actuellement connecté, veuillez demander à un autre administrateur de le faire.",
 	"patient_muddy_llama_work": "Impossible de supprimer l'enregistrement d'administrateur d'instance par défaut",
 	"low_petty_martin_dazzle": "Impossible de supprimer uniquement le compte administrateur de l'organisation. Veuillez contacter l'assistance si vous souhaitez supprimer l'intégralité du compte de l'organisation.",
 	"ornate_real_swallow_honor": "Erreur lors de la suppression de l'enregistrement administrateur. L'enregistrement n'a pas été supprimé."

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "CSS personnalisé",
 	"aqua_north_fox_grace": "Javascript personnalisé",
 	"teary_sharp_starfish_honor": "CSS personnalisé",
+	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript personnalisé",
 	"sharp_sea_anteater_walk": "Télécharger ou sélectionner l'image principale",
 	"still_zany_warbler_savor": "Télécharger ou sélectionner l'image principale",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "Vous ne pouvez pas vous supprimer vous-même. Si vous souhaitez supprimer le compte administrateur actuellement connecté, veuillez demander à un autre administrateur de le faire.",
 	"patient_muddy_llama_work": "Impossible de supprimer l'enregistrement d'administrateur d'instance par défaut",
 	"low_petty_martin_dazzle": "Impossible de supprimer uniquement le compte administrateur de l'organisation. Veuillez contacter l'assistance si vous souhaitez supprimer l'intégralité du compte de l'organisation.",
-	"ornate_real_swallow_honor": "Erreur lors de la suppression de l'enregistrement administrateur. L'enregistrement n'a pas été supprimé."
+	"ornate_real_swallow_honor": "Erreur lors de la suppression de l'enregistrement administrateur. L'enregistrement n'a pas été supprimé.",
+	"happy_inclusive_hyena_cuddle": "Erreur lors de la suppression de l'enregistrement. Veuillez réessayer.",
+	"elegant_whole_mayfly_zap": "L'administrateur a été supprimé avec succès",
+	"wide_major_pig_swim": "Supprimer",
+	"moving_acidic_crow_imagine": "Êtes-vous sûr de vouloir supprimer cet enregistrement ? Cette action est irréversible."
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "カスタム CSS",
 	"aqua_north_fox_grace": "カスタムJavascript",
 	"teary_sharp_starfish_honor": "カスタム CSS",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "カスタムJavascript",
 	"sharp_sea_anteater_walk": "特集画像をアップロードまたは選択",
 	"still_zany_warbler_savor": "特集画像をアップロードまたは選択",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "女性",
 	"teal_maroon_mantis_scoop": "他の",
 	"awake_topical_rook_jolt": "指定されていない",
-  "wide_male_parrot_enrich": "自分自身を削除することはできません。現在サインインしている管理者アカウントを削除する場合は、別の管理者に削除を依頼してください。",
+	"wide_male_parrot_enrich": "自分自身を削除することはできません。現在サインインしている管理者アカウントを削除する場合は、別の管理者に削除を依頼してください。",
 	"patient_muddy_llama_work": "デフォルトのインスタンス管理者レコードを削除できません",
 	"low_petty_martin_dazzle": "組織内の管理者のみを削除することはできません。組織アカウント全体を削除する場合は、サポートにお問い合わせください。",
 	"ornate_real_swallow_honor": "管理者レコードの削除中にエラーが発生しました。レコードは削除されませんでした。"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "カスタム CSS",
 	"aqua_north_fox_grace": "カスタムJavascript",
 	"teary_sharp_starfish_honor": "カスタム CSS",
+	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "カスタムJavascript",
 	"sharp_sea_anteater_walk": "特集画像をアップロードまたは選択",
 	"still_zany_warbler_savor": "特集画像をアップロードまたは選択",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "自分自身を削除することはできません。現在サインインしている管理者アカウントを削除する場合は、別の管理者に削除を依頼してください。",
 	"patient_muddy_llama_work": "デフォルトのインスタンス管理者レコードを削除できません",
 	"low_petty_martin_dazzle": "組織内の管理者のみを削除することはできません。組織アカウント全体を削除する場合は、サポートにお問い合わせください。",
-	"ornate_real_swallow_honor": "管理者レコードの削除中にエラーが発生しました。レコードは削除されませんでした。"
+	"ornate_real_swallow_honor": "管理者レコードの削除中にエラーが発生しました。レコードは削除されませんでした。",
+	"happy_inclusive_hyena_cuddle": "レコードの削除中にエラーが発生しました。もう一度お試しください。",
+	"elegant_whole_mayfly_zap": "管理者が正常に削除されました",
+	"wide_major_pig_swim": "消去",
+	"moving_acidic_crow_imagine": "このレコードを削除してもよろしいですか? この操作は元に戻せません。"
 }

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "カスタム CSS",
 	"aqua_north_fox_grace": "カスタムJavascript",
 	"teary_sharp_starfish_honor": "カスタム CSS",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "カスタムJavascript",
 	"sharp_sea_anteater_walk": "特集画像をアップロードまたは選択",
 	"still_zany_warbler_savor": "特集画像をアップロードまたは選択",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS personalizado",
 	"aqua_north_fox_grace": "Javascript personalizado",
 	"teary_sharp_starfish_honor": "CSS personalizado",
-	"misty_awful_kitten_walk": "dados.t.forms.campos.código_personalizado.js_personalizado.rótulo()",
 	"plain_real_clownfish_flow": "Javascript personalizado",
 	"sharp_sea_anteater_walk": "Carregar ou selecionar imagem de destaque",
 	"still_zany_warbler_savor": "Carregar ou selecionar imagem de destaque",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "Fêmea",
 	"teal_maroon_mantis_scoop": "Outro",
 	"awake_topical_rook_jolt": "Não especificado",
-  "wide_male_parrot_enrich": "Você não pode excluir a si mesmo. Se desejar excluir a conta de administrador atualmente conectada, peça a outro administrador para excluí-la.",
+	"wide_male_parrot_enrich": "Você não pode excluir a si mesmo. Se desejar excluir a conta de administrador atualmente conectada, peça a outro administrador para excluí-la.",
 	"patient_muddy_llama_work": "Não é possível excluir o registro do administrador da instância padrão",
 	"low_petty_martin_dazzle": "Não é possível excluir apenas o administrador na organização. Entre em contato com o suporte se desejar excluir a conta inteira da organização.",
 	"ornate_real_swallow_honor": "Erro ao excluir registro de administrador. O registro não foi excluído."

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "CSS personalizado",
 	"aqua_north_fox_grace": "Javascript personalizado",
 	"teary_sharp_starfish_honor": "CSS personalizado",
+	"misty_awful_kitten_walk": "dados.t.forms.campos.código_personalizado.js_personalizado.rótulo()",
 	"plain_real_clownfish_flow": "Javascript personalizado",
 	"sharp_sea_anteater_walk": "Carregar ou selecionar imagem de destaque",
 	"still_zany_warbler_savor": "Carregar ou selecionar imagem de destaque",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "Você não pode excluir a si mesmo. Se desejar excluir a conta de administrador atualmente conectada, peça a outro administrador para excluí-la.",
 	"patient_muddy_llama_work": "Não é possível excluir o registro do administrador da instância padrão",
 	"low_petty_martin_dazzle": "Não é possível excluir apenas o administrador na organização. Entre em contato com o suporte se desejar excluir a conta inteira da organização.",
-	"ornate_real_swallow_honor": "Erro ao excluir registro de administrador. O registro não foi excluído."
+	"ornate_real_swallow_honor": "Erro ao excluir registro de administrador. O registro não foi excluído.",
+	"happy_inclusive_hyena_cuddle": "Erro ao excluir registro. Tente novamente",
+	"elegant_whole_mayfly_zap": "O administrador foi excluído com sucesso",
+	"wide_major_pig_swim": "Excluir",
+	"moving_acidic_crow_imagine": "Tem certeza de que deseja excluir este registro. Esta ação não pode ser desfeita?"
 }

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "CSS maalum",
 	"aqua_north_fox_grace": "Javascript Maalum",
 	"teary_sharp_starfish_honor": "CSS maalum",
+	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript Maalum",
 	"sharp_sea_anteater_walk": "Pakia au chagua picha ya kipengele",
 	"still_zany_warbler_savor": "Pakia au chagua picha ya kipengele",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "Huwezi kujifuta. Ikiwa ungependa kufuta akaunti ya msimamizi ambayo kwa sasa umeingia, tafadhali muulize msimamizi mwingine aifute.",
 	"patient_muddy_llama_work": "Haiwezi kufuta rekodi ya msimamizi wa mfano chaguo-msingi",
 	"low_petty_martin_dazzle": "Haiwezi kufuta msimamizi katika shirika pekee. Tafadhali wasiliana na usaidizi ikiwa ungependa kufuta akaunti nzima ya shirika.",
-	"ornate_real_swallow_honor": "Hitilafu katika kufuta rekodi ya msimamizi. Rekodi haikufutwa."
+	"ornate_real_swallow_honor": "Hitilafu katika kufuta rekodi ya msimamizi. Rekodi haikufutwa.",
+	"happy_inclusive_hyena_cuddle": "Hitilafu katika kufuta rekodi. Tafadhali jaribu tena",
+	"elegant_whole_mayfly_zap": "Msimamizi alifutwa",
+	"wide_major_pig_swim": "Futa",
+	"moving_acidic_crow_imagine": "Je, una uhakika unataka kufuta rekodi hii. Kitendo hiki hakiwezi kutenduliwa?"
 }

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS maalum",
 	"aqua_north_fox_grace": "Javascript Maalum",
 	"teary_sharp_starfish_honor": "CSS maalum",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript Maalum",
 	"sharp_sea_anteater_walk": "Pakia au chagua picha ya kipengele",
 	"still_zany_warbler_savor": "Pakia au chagua picha ya kipengele",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "Mwanamke",
 	"teal_maroon_mantis_scoop": "Nyingine",
 	"awake_topical_rook_jolt": "Haijabainishwa",
-  "wide_male_parrot_enrich": "Huwezi kujifuta. Ikiwa ungependa kufuta akaunti ya msimamizi ambayo kwa sasa umeingia, tafadhali muulize msimamizi mwingine aifute.",
+	"wide_male_parrot_enrich": "Huwezi kujifuta. Ikiwa ungependa kufuta akaunti ya msimamizi ambayo kwa sasa umeingia, tafadhali muulize msimamizi mwingine aifute.",
 	"patient_muddy_llama_work": "Haiwezi kufuta rekodi ya msimamizi wa mfano chaguo-msingi",
 	"low_petty_martin_dazzle": "Haiwezi kufuta msimamizi katika shirika pekee. Tafadhali wasiliana na usaidizi ikiwa ungependa kufuta akaunti nzima ya shirika.",
 	"ornate_real_swallow_honor": "Hitilafu katika kufuta rekodi ya msimamizi. Rekodi haikufutwa."

--- a/messages/sw.json
+++ b/messages/sw.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS maalum",
 	"aqua_north_fox_grace": "Javascript Maalum",
 	"teary_sharp_starfish_honor": "CSS maalum",
-	"misty_awful_kitten_walk": "data.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "Javascript Maalum",
 	"sharp_sea_anteater_walk": "Pakia au chagua picha ya kipengele",
 	"still_zany_warbler_savor": "Pakia au chagua picha ya kipengele",

--- a/messages/th.json
+++ b/messages/th.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "CSS ที่กำหนดเอง",
 	"aqua_north_fox_grace": "จาวาสคริปต์ที่กำหนดเอง",
 	"teary_sharp_starfish_honor": "CSS ที่กำหนดเอง",
-	"misty_awful_kitten_walk": "ข้อมูล.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "จาวาสคริปต์ที่กำหนดเอง",
 	"sharp_sea_anteater_walk": "อัพโหลดหรือเลือกภาพเด่น",
 	"still_zany_warbler_savor": "อัพโหลดหรือเลือกภาพเด่น",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "หญิง",
 	"teal_maroon_mantis_scoop": "อื่น",
 	"awake_topical_rook_jolt": "ไม่ระบุ",
-  "wide_male_parrot_enrich": "คุณไม่สามารถลบตัวเองได้ หากคุณต้องการลบบัญชีผู้ดูแลระบบที่ลงชื่อเข้าใช้ในปัจจุบัน โปรดขอให้ผู้ดูแลระบบคนอื่นลบบัญชีดังกล่าว",
+	"wide_male_parrot_enrich": "คุณไม่สามารถลบตัวเองได้ หากคุณต้องการลบบัญชีผู้ดูแลระบบที่ลงชื่อเข้าใช้ในปัจจุบัน โปรดขอให้ผู้ดูแลระบบคนอื่นลบบัญชีดังกล่าว",
 	"patient_muddy_llama_work": "ไม่สามารถลบข้อมูลผู้ดูแลระบบอินสแตนซ์เริ่มต้นได้",
 	"low_petty_martin_dazzle": "ไม่สามารถลบเฉพาะผู้ดูแลระบบในองค์กรได้ โปรดติดต่อฝ่ายสนับสนุนหากคุณต้องการลบบัญชีองค์กรทั้งหมด",
 	"ornate_real_swallow_honor": "เกิดข้อผิดพลาดในการลบข้อมูลผู้ดูแลระบบ ข้อมูลไม่ถูกลบ"

--- a/messages/th.json
+++ b/messages/th.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "CSS ที่กำหนดเอง",
 	"aqua_north_fox_grace": "จาวาสคริปต์ที่กำหนดเอง",
 	"teary_sharp_starfish_honor": "CSS ที่กำหนดเอง",
+	"misty_awful_kitten_walk": "ข้อมูล.t.forms.fields.custom_code.custom_js.label()",
 	"plain_real_clownfish_flow": "จาวาสคริปต์ที่กำหนดเอง",
 	"sharp_sea_anteater_walk": "อัพโหลดหรือเลือกภาพเด่น",
 	"still_zany_warbler_savor": "อัพโหลดหรือเลือกภาพเด่น",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "คุณไม่สามารถลบตัวเองได้ หากคุณต้องการลบบัญชีผู้ดูแลระบบที่ลงชื่อเข้าใช้ในปัจจุบัน โปรดขอให้ผู้ดูแลระบบคนอื่นลบบัญชีดังกล่าว",
 	"patient_muddy_llama_work": "ไม่สามารถลบข้อมูลผู้ดูแลระบบอินสแตนซ์เริ่มต้นได้",
 	"low_petty_martin_dazzle": "ไม่สามารถลบเฉพาะผู้ดูแลระบบในองค์กรได้ โปรดติดต่อฝ่ายสนับสนุนหากคุณต้องการลบบัญชีองค์กรทั้งหมด",
-	"ornate_real_swallow_honor": "เกิดข้อผิดพลาดในการลบข้อมูลผู้ดูแลระบบ ข้อมูลไม่ถูกลบ"
+	"ornate_real_swallow_honor": "เกิดข้อผิดพลาดในการลบข้อมูลผู้ดูแลระบบ ข้อมูลไม่ถูกลบ",
+	"happy_inclusive_hyena_cuddle": "เกิดข้อผิดพลาดในการลบข้อมูล กรุณาลองใหม่อีกครั้ง",
+	"elegant_whole_mayfly_zap": "ลบแอดมินสำเร็จแล้ว",
+	"wide_major_pig_swim": "ลบ",
+	"moving_acidic_crow_imagine": "คุณแน่ใจหรือไม่ว่าต้องการลบข้อมูลนี้ การดำเนินการนี้ไม่สามารถย้อนกลับได้?"
 }

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -439,7 +439,6 @@
 	"just_giant_pony_urge": "自定义 CSS",
 	"aqua_north_fox_grace": "自定义 Javascript",
 	"teary_sharp_starfish_honor": "自定义 CSS",
-	"misty_awful_kitten_walk": "数据.t.forms.fields.custom_code.custom_js.标签()",
 	"plain_real_clownfish_flow": "自定义 Javascript",
 	"sharp_sea_anteater_walk": "上传或选择特色图片",
 	"still_zany_warbler_savor": "上传或选择特色图片",
@@ -556,7 +555,7 @@
 	"clean_sea_thrush_dial": "女性",
 	"teal_maroon_mantis_scoop": "其他",
 	"awake_topical_rook_jolt": "未指定",
-  "wide_male_parrot_enrich": "您无法删除自己。如果您希望删除当前登录的管理员帐户，请让其他管理员将其删除。",
+	"wide_male_parrot_enrich": "您无法删除自己。如果您希望删除当前登录的管理员帐户，请让其他管理员将其删除。",
 	"patient_muddy_llama_work": "无法删除默认实例管理员记录",
 	"low_petty_martin_dazzle": "无法仅删除组织中的管理员。如果您希望删除整个组织帐户，请联系支持人员。",
 	"ornate_real_swallow_honor": "删除管理记录时出错。记录未被删除。"

--- a/messages/zh.json
+++ b/messages/zh.json
@@ -439,6 +439,7 @@
 	"just_giant_pony_urge": "自定义 CSS",
 	"aqua_north_fox_grace": "自定义 Javascript",
 	"teary_sharp_starfish_honor": "自定义 CSS",
+	"misty_awful_kitten_walk": "数据.t.forms.fields.custom_code.custom_js.标签()",
 	"plain_real_clownfish_flow": "自定义 Javascript",
 	"sharp_sea_anteater_walk": "上传或选择特色图片",
 	"still_zany_warbler_savor": "上传或选择特色图片",
@@ -558,5 +559,9 @@
 	"wide_male_parrot_enrich": "您无法删除自己。如果您希望删除当前登录的管理员帐户，请让其他管理员将其删除。",
 	"patient_muddy_llama_work": "无法删除默认实例管理员记录",
 	"low_petty_martin_dazzle": "无法仅删除组织中的管理员。如果您希望删除整个组织帐户，请联系支持人员。",
-	"ornate_real_swallow_honor": "删除管理记录时出错。记录未被删除。"
+	"ornate_real_swallow_honor": "删除管理记录时出错。记录未被删除。",
+	"happy_inclusive_hyena_cuddle": "删除记录时出错。请重试",
+	"elegant_whole_mayfly_zap": "管理员已成功删除",
+	"wide_major_pig_swim": "删除",
+	"moving_acidic_crow_imagine": "您确实要删除此记录吗？此操作无法撤消？"
 }

--- a/src/routes/(app)/settings/admins/+page.svelte
+++ b/src/routes/(app)/settings/admins/+page.svelte
@@ -17,11 +17,11 @@
 			});
 			if (!response.ok) throw new Error('Failed to delete admin');
 
-			$flash = { type: 'success', message: data.t.forms.actions.success() };
+			$flash = { type: 'success', message: m.elegant_whole_mayfly_zap() };
 			goto('/settings/admins', { invalidateAll: true });
 		} catch (error) {
 			console.error('Error deleting admin: ', error);
-			$flash = { type: 'error', message: data.t.forms.actions.failed() };
+			$flash = { type: 'error', message: m.happy_inclusive_hyena_cuddle() };
 		}
 	}
 </script>
@@ -66,12 +66,12 @@
 					size="sm"
 					variant="destructive"
 					on:click={() => {
-						if (window.confirm(data.t.forms.messages.confirm_delete())) {
+						if (window.confirm("Are you sure you want to delete this record. This action cannot be undone?")) {
 							deleteAdmin(admin.id);
 						}
 					}}
 				>
-					{data.t.forms.buttons.delete()}
+					{"Delete"}
 				</Button>
 			</div>
 		</div>

--- a/src/routes/(app)/settings/admins/+page.svelte
+++ b/src/routes/(app)/settings/admins/+page.svelte
@@ -66,12 +66,12 @@
 					size="sm"
 					variant="destructive"
 					on:click={() => {
-						if (window.confirm("Are you sure you want to delete this record. This action cannot be undone?")) {
+						if (window.confirm(m.moving_acidic_crow_imagine())) {
 							deleteAdmin(admin.id);
 						}
 					}}
 				>
-					{"Delete"}
+					{m.wide_major_pig_swim()}
 				</Button>
 			</div>
 		</div>


### PR DESCRIPTION
A very simple PR just converting a page to make sure it uses the new localization system. Should be no real flow-on effects. 

I had an error when running tests on my development laptop where it didn't seem able to resolve the paraglide modules when imported in test files. Not sure why that would happen, so hopefully it was just an issue with the development server. I will check to see if the test suite runs correctly here. 