### PR TITLE
Update template selection widget to change template name and ID

### DIFF
--- a/src/lib/comps/forms/whatsapp/messages/builder/actions/thread.ts
+++ b/src/lib/comps/forms/whatsapp/messages/builder/actions/thread.ts
@@ -51,13 +51,17 @@ export async function updateThread({
 	messageId,
 	actions,
 	templateName,
-	components
+	components,
+	templateId,
+	threadId
 }: {
 	templateMessage: UpdateMessage['message'];
 	messageId: string;
 	templateName: string;
 	actions: UpdateMessage['actions'];
 	components: TemplateForComponents['components'];
+	templateId: number;
+	threadId: number;
 }): Promise<ReadMessage> {
 	if (templateMessage && templateMessage.type === 'template') {
 		const updateThreadBody: UpdateMessage = {
@@ -71,16 +75,28 @@ export async function updateThread({
 				}
 			}
 		};
+
+		const threadResponse = await fetch(`/api/v1/communications/whatsapp/threads/${threadId}`, {
+			method: 'PUT',
+			body: JSON.stringify({
+				template_id: templateId
+			})
+		});
+		if (!threadResponse.ok) {
+			throw new Error('Failed to update thread');
+		}
+		const parsedThread = parse(readThread, await threadResponse.json());
+
 		const parsedUpdateThreadBody = parse(updateMessage, updateThreadBody);
-		console.log(parsedUpdateThreadBody);
 		const messageRes = await fetch(`/api/v1/communications/whatsapp/messages/${messageId}`, {
 			method: 'PUT',
 			body: JSON.stringify(parsedUpdateThreadBody)
 		});
 		if (!messageRes.ok) {
-			console.error('Failed to update message', messageRes);
+			throw new Error('Failed to update message');
 		}
 		const parsed = parse(readMessage, await messageRes.json());
+
 		return parsed;
 	} else {
 		throw new Error('Invalid message type');

--- a/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
+++ b/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
@@ -54,7 +54,9 @@
 			if (template && templateMessage.type === 'template') {
 				await threadActions.updateThread({
 					templateMessage,
+					templateId,
 					actions,
+					threadId: data.thread.id,
 					templateName: templateMessage.template.name, //template
 					components,
 					messageId: data.thread.template_message_id
@@ -97,6 +99,11 @@
 						actions,
 						templateMessage
 					);
+					if ('template' in templateMessage) {
+						//should always be true
+						templateMessage.template.name = template.message.name;
+						templateId = template.id;
+					}
 					components = output.components;
 					actions = output.actions;
 					await saveThread();


### PR DESCRIPTION
This fixes the error identified on sending messages using the free response template: 

```
"errorCode": "132000",
      "errorMessage": "header: number of localizable_params (0) does not match the expected number of params (1)",
      "createTime": "2025-03-28T07:35:14.591Z",
      "updateTime": "2025-03-28T07:35:15.034Z",
      "totalPrice": 0,
      "pricingCategory": "marketing",
      "currency": "USD",
      "regionCode": "KE",
      "whatsappApiError": {
        "message": "(#132000) Number of parameters does not match the expected number of params",
        "type": "OAuthException",
        "code": "132000",
        "fbtrace_id": "AZb5VRLKGwZJ1-oateuaeAl",
        "error_data": {
          "messaging_product": "whatsapp",
          "details": "header: number of localizable_params (0) does not match the expected number of params (1)"
        },
        "errorDataDetails": "header: number of localizable_params (0) does not match the expected number of params (1)"
      },
      "bizType": "whatsapp" 
``` 
      
After some investigation, this ended up being because the "name" in the template message body was not being updated correctly when the template widget was changed. This is a regression introduced by the past changes to the WhatsApp thread authoring components. 

The solution was to make sure that the template name is changed correctly when the template for a thread is updated. It also required updating the `template_id` in the `communications.whatsapp_threads` table, in order to make sure that the template selector dropdown on the thread editing page displays the correct template. 

Note: This is the second time there has been a regression related to template names. The first time was the template human readable name being listed, instead of the unique name registered with WhatsApp. 