### PR TITLE
New husky action to stop commits to main

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,1 +1,8 @@
 npm run check-console-logs
+
+# Block direct pushes to main
+branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$branch" = "main" ]; then
+  echo "🚫 Direct pushes to 'main' are blocked. Use a pull request instead."
+  exit 1
+fi


### PR DESCRIPTION
I have accidentally pushed to main a couple of times when making small changes due to having that branch open. 

Unfortunately, under a free plan admins can't be restricted from pushing to main, so this is a hook to block all pushes to main. 