### PR TITLE
Stop country name from blocking event creation

### DIFF
--- a/src/routes/(app)/events/new/+page.server.ts
+++ b/src/routes/(app)/events/new/+page.server.ts
@@ -14,7 +14,10 @@ import { parse } from '$lib/schema/valibot';
 const log = pino(import.meta.url);
 export async function load(event) {
 	const form = await superValidate(
-		{ ...event.locals.instance.settings.events.default_event_info_settings },
+		{
+			...event.locals.instance.settings.events.default_event_info_settings,
+			country: event.locals.instance.country
+		},
 		valibot(create),
 		{ errors: false } //does not set errors on form load (tainted/dirty fields with errors will still display, though)
 	);


### PR DESCRIPTION
Event country is a required field for new event creation, however if the event is an online event, then the field for entering the country is obscured. And the form does not subject (validation) but the error message (on the field) is hidden.

This simple fix makes the instance country the default country for new events, meaning that the country field is populated and the form does not fail.