### PR TITLE
Exclude lucide-svelte icon library from dependency optimization

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,7 @@ import { paraglideVitePlugin } from '@inlang/paraglide-js';
 
 export default defineConfig({
 	optimizeDeps: {
-		include: ['lucide-svelte']
+		exclude: ['lucide-svelte']
 	},
 	plugins: [
 		sentrySvelteKit(),


### PR DESCRIPTION
I have found that excluding this seems to lead to fewer instances of the dev server crashing. I quite frequently get 500 errors on the development server, with error messages from vite telling me it can't find particulr chunks which almost always appear to reference lucide, this icon library.

I don't have a good understanding of vite internals or a theory of why this happens, but I have experimented with both including and excluding lucide, and I think that excluding appears to lead to more stable behavior.

I'm happy to dump this PR if there are better options out there though :)