### PR TITLE
Delete website uploads

### DIFF
--- a/src/lib/comps/widgets/uploads/RenderUpload.svelte
+++ b/src/lib/comps/widgets/uploads/RenderUpload.svelte
@@ -4,15 +4,24 @@
 	const {
 		upload,
 		showCopyButton = false,
+		showDeleteButton = false,
+		onDelete = () => {},
 		children
-	}: { upload: List['items'][number]; showCopyButton: boolean; children?: Snippet } = $props();
+	}: {
+		upload: List['items'][number];
+		showCopyButton: boolean;
+		showDeleteButton?: boolean;
+		onDelete?: (id: number) => void;
+		children?: Snippet;
+	} = $props();
 	import { humanReadableFileSize } from '$lib/utils/text/file_size';
 	import Button from '$lib/comps/ui/button/button.svelte';
-	import { page } from '$app/stores';
+	import { page } from '$app/state';
 	import { getFlash } from 'sveltekit-flash-message';
 	import Badge from '$lib/comps/ui/badge/badge.svelte';
 	const flash = getFlash(page);
 	import * as m from '$lib/paraglide/messages';
+	import { Trash2Icon } from 'lucide-svelte';
 
 	function copy() {
 		navigator.clipboard.writeText(upload.url);
@@ -31,8 +40,20 @@
 			<div><Badge variant="secondary">{humanReadableFileSize(upload.size, true)}</Badge></div>
 		</div>
 		{#if children}{@render children()}{/if}
-		{#if showCopyButton}<div class="flex justify-center mt-3">
+		<div class="flex justify-center mt-3 gap-2">
+			{#if showCopyButton}
 				<Button variant="outline" size="sm" onclick={copy}>{m.loud_spicy_wombat_reside()}</Button>
-			</div>{/if}
+			{/if}
+			{#if showDeleteButton}
+				<Button
+					variant="destructive"
+					size="sm"
+					onclick={() => onDelete(upload.id)}
+					title={m.wide_major_pig_swim()}
+				>
+					<Trash2Icon class="w-4 h-4" />
+				</Button>
+			{/if}
+		</div>
 	</div>
 </div>

--- a/src/lib/server/api/website/uploads.ts
+++ b/src/lib/server/api/website/uploads.ts
@@ -100,10 +100,13 @@ export async function del({
 	await db
 		.update(
 			'website.uploads',
-			{ instance_id: instanceId, id: uploadId },
-			{ deleted_at: new Date() }
+			{ deleted_at: new Date() },
+			{ instance_id: instanceId, id: uploadId }
 		)
-		.run(pool);
+		.run(pool)
+		.catch((err) => {
+			throw new BelcodaError(404, 'DATA:WEBSITE:UPLOADS:DEL:01', m.pretty_tired_fly_lead(), err);
+		});
 	await redis.del(redisString(instanceId, uploadId));
 	await redis.del(redisString(instanceId, 'all'));
 }

--- a/src/lib/server/api/website/uploads.ts
+++ b/src/lib/server/api/website/uploads.ts
@@ -81,3 +81,21 @@ export async function list({
 	await redis.set(redisString(instanceId, 'all'), parsedResult);
 	return parsedResult;
 }
+
+export async function del({
+	instanceId,
+	uploadId
+}: {
+	instanceId: number;
+	uploadId: number;
+}): Promise<void> {
+	await db
+		.update(
+			'website.uploads',
+			{ instance_id: instanceId, id: uploadId },
+			{ deleted_at: new Date() }
+		)
+		.run(pool);
+	await redis.del(redisString(instanceId, uploadId));
+	await redis.del(redisString(instanceId, 'all'));
+}

--- a/src/routes/(api)/api/v1/website/uploads/[upload_id]/+server.ts
+++ b/src/routes/(api)/api/v1/website/uploads/[upload_id]/+server.ts
@@ -19,3 +19,21 @@ export async function GET(event) {
 		);
 	}
 }
+
+export async function DELETE(event) {
+	try {
+		const uploadId = Number(event.params.upload_id);
+		const upload = await api.del({
+			instanceId: event.locals.instance.id,
+			uploadId
+		});
+		return json(upload);
+	} catch (err) {
+		return error(
+			500,
+			'API:/api/v1/website/uploads/[upload_id]/:DELETE:01',
+			m.spry_ago_baboon_cure(),
+			err
+		);
+	}
+}

--- a/src/routes/(api)/api/v1/website/uploads/[upload_id]/+server.ts
+++ b/src/routes/(api)/api/v1/website/uploads/[upload_id]/+server.ts
@@ -6,8 +6,7 @@ export async function GET(event) {
 		const uploadId = Number(event.params.upload_id);
 		const upload = await api.read({
 			instanceId: event.locals.instance.id,
-			uploadId,
-			t: event.locals.t
+			uploadId
 		});
 		return json(upload);
 	} catch (err) {
@@ -23,11 +22,11 @@ export async function GET(event) {
 export async function DELETE(event) {
 	try {
 		const uploadId = Number(event.params.upload_id);
-		const upload = await api.del({
+		const response = await api.del({
 			instanceId: event.locals.instance.id,
 			uploadId
 		});
-		return json(upload);
+		return json(response);
 	} catch (err) {
 		return error(
 			500,

--- a/src/routes/(app)/website/uploads/+page.svelte
+++ b/src/routes/(app)/website/uploads/+page.svelte
@@ -17,6 +17,8 @@
 			if (!response.ok) {
 				throw new Error(m.keen_agent_shell_mop());
 			}
+			$flash = { type: 'success', message: m.dizzy_actual_elephant_evoke() };
+			window.location.reload();
 		} catch (error) {
 			if (error instanceof Error) {
 				$flash = { type: 'error', message: error.message };

--- a/src/routes/(app)/website/uploads/+page.svelte
+++ b/src/routes/(app)/website/uploads/+page.svelte
@@ -4,6 +4,27 @@
 	import DataGrid from '$lib/comps/ui/custom/table/DataGrid.svelte';
 	import Button from '$lib/comps/ui/button/button.svelte';
 	import RenderUpload from '$lib/comps/widgets/uploads/RenderUpload.svelte';
+	import { page } from '$app/state';
+	import { getFlash } from 'sveltekit-flash-message';
+	const flash = getFlash(page);
+
+	async function deleteUpload(id: number) {
+		if (!confirm(m.moving_acidic_crow_imagine())) return;
+		try {
+			const response = await fetch(`/api/v1/website/uploads/${id}`, {
+				method: 'DELETE'
+			});
+			if (!response.ok) {
+				throw new Error(m.keen_agent_shell_mop());
+			}
+		} catch (error) {
+			if (error instanceof Error) {
+				$flash = { type: 'error', message: error.message };
+			} else {
+				$flash = { type: 'error', message: m.teary_dizzy_earthworm_urge() };
+			}
+		}
+	}
 </script>
 
 <DataGrid
@@ -24,6 +45,11 @@
 		<Button href="/website/uploads/new">{m.mild_fine_bulldog_zip()}</Button>
 	{/snippet}
 	{#snippet content(item: (typeof data.uploads.items)[0])}
-		<RenderUpload upload={item} showCopyButton={true} />
+		<RenderUpload
+			upload={item}
+			showCopyButton={true}
+			showDeleteButton={true}
+			onDelete={deleteUpload}
+		/>
 	{/snippet}
 </DataGrid>


### PR DESCRIPTION
This PR adds soft deletion of website uploads.

The deletion currently removes the upload from the list of uploads you can select to add to a post but does not delete the uploads from already posted content. It can be added, but that would mean that the post will no longer have the image attached to it. If this is what we want, let me know and I will update it on this PR.