### PR TITLE
Patch/umami analytics dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,3 +88,4 @@ OPENAI_API_KEY=
 #ANALYTICS (using https://umami.is/)
 UMAMI_API_KEY=
 PUBLIC_UMAMI_WEBSITE_ID=
+PUBLIC_UMAMI_REFERRER_ID= #A simple UUID used as a default referrer for analytics events.

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -1,5 +1,9 @@
 import { UMAMI_API_KEY } from '$env/static/private';
-import { PUBLIC_UMAMI_WEBSITE_ID, PUBLIC_ROOT_DOMAIN } from '$env/static/public';
+import {
+	PUBLIC_UMAMI_WEBSITE_ID,
+	PUBLIC_ROOT_DOMAIN,
+	PUBLIC_UMAMI_REFERRER_ID
+} from '$env/static/public';
 import { type RequestEvent } from '@sveltejs/kit';
 import { pino } from '$lib/server';
 import { dev } from '$app/environment';
@@ -9,7 +13,7 @@ export default async function (event: RequestEvent): Promise<void> {
 		const payload = {
 			hostname: event.url.hostname,
 			language: event.locals.language,
-			referrer: event.request.headers.get('referer') || '',
+			referrer: event.request.headers.get('referer') || PUBLIC_UMAMI_REFERRER_ID,
 			domain: PUBLIC_ROOT_DOMAIN,
 			screen: 'N/A',
 			title: 'N/A',
@@ -21,7 +25,7 @@ export default async function (event: RequestEvent): Promise<void> {
 				id: event.locals.admin?.id || 'UNKNOWN'
 			}
 		};
-		if (!dev) {
+		if (dev) {
 			const headers = {
 				'Content-Type': 'application/json',
 				'x-umami-api-key': UMAMI_API_KEY,

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -25,7 +25,7 @@ export default async function (event: RequestEvent): Promise<void> {
 				id: event.locals.admin?.id || 'UNKNOWN'
 			}
 		};
-		if (dev) {
+		if (!dev) {
 			const headers = {
 				'Content-Type': 'application/json',
 				'x-umami-api-key': UMAMI_API_KEY,

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -9,13 +9,11 @@ export default async function (event: RequestEvent): Promise<void> {
 		const payload = {
 			hostname: event.url.hostname,
 			language: event.locals.language,
-			domain: event.url.hostname,
 			referrer: event.request.headers.get('referer') || '',
 			domain: PUBLIC_ROOT_DOMAIN,
 			screen: 'N/A',
 			title: 'N/A',
 			url: event.url.href,
-			url: `${event.url.href}`,
 			name: `${event.request.method}`,
 			website: PUBLIC_UMAMI_WEBSITE_ID,
 			data: {

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -9,8 +9,8 @@ export default async function (event: RequestEvent): Promise<void> {
 		const payload = {
 			hostname: event.url.hostname,
 			language: event.locals.language,
-			referrer: event.request.headers.get('referer'),
 			domain: event.url.hostname,
+			referrer: event.request.headers.get('referer') || '',
 			domain: PUBLIC_ROOT_DOMAIN,
 			screen: 'N/A',
 			title: 'N/A',

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -13,7 +13,7 @@ export default async function (event: RequestEvent): Promise<void> {
 		const payload = {
 			hostname: event.url.hostname,
 			language: event.locals.language,
-			referrer: event.request.headers.get('referer') || PUBLIC_UMAMI_REFERRER_ID,
+			referrer: event.request.headers.get('referer') || PUBLIC_UMAMI_REFERRER_ID || '',
 			domain: PUBLIC_ROOT_DOMAIN,
 			screen: 'N/A',
 			title: 'N/A',

--- a/src/lib/server/hooks/analytics/log.ts
+++ b/src/lib/server/hooks/analytics/log.ts
@@ -1,5 +1,5 @@
 import { UMAMI_API_KEY } from '$env/static/private';
-import { PUBLIC_UMAMI_WEBSITE_ID } from '$env/static/public';
+import { PUBLIC_UMAMI_WEBSITE_ID, PUBLIC_ROOT_DOMAIN } from '$env/static/public';
 import { type RequestEvent } from '@sveltejs/kit';
 import { pino } from '$lib/server';
 const log = pino(import.meta.url);
@@ -10,9 +10,11 @@ export default async function (event: RequestEvent): Promise<void> {
 			language: event.locals.language,
 			referrer: event.request.headers.get('referer'),
 			domain: event.url.hostname,
+			domain: PUBLIC_ROOT_DOMAIN,
 			screen: 'N/A',
 			title: 'N/A',
 			url: event.url.href,
+			url: `${event.url.href}`,
 			name: `${event.request.method}`,
 			website: PUBLIC_UMAMI_WEBSITE_ID,
 			data: {


### PR DESCRIPTION
A small patch to stop the umami analytics module from generating a bunch of errors.

The issue is that referrer is a required parameter in their API. And because we're using their API for API routes that generate inside the app, the referrer header isn't set, which resulted in `null` being sent to the Umami API. This caused a validation error at their end, which resulted in our attempts to log fail, and an error being thrown.

This replaces the `null` value with an empty string, which appears to pass their validation, and matches their API docs.

This change also stops analytics events being run from the dev server, so that we only track analytics events coming from production.