### PR TITLE
Feature/add migrations to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,11 @@ COPY ./svelte.config.js ./
 COPY ./vite.config.ts ./
 COPY ./.env.production ./.env
 COPY ./project.inlang ./project.inlang
+COPY ./ca-certificate.crt ./
+COPY ./knexfile.cjs ./
+COPY ./db ./db
+RUN npm install knex
+RUN npm run knex:migrate:production
 RUN npm install
 COPY . .
 ENV NODE_OPTIONS=--max_old_space_size=4096

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,8 @@ services:
     app:
         container_name: app
         restart: unless-stopped
+        dns: 
+          - 8.8.8.8
         build:
           context: ./
         depends_on:


### PR DESCRIPTION
This adds production migrations to the Docker script, using the existing `PRODUCTION_DATABASE_URL` environment variable, which exists on the production server. 

It has a couple of small updates to the dockerfile to make this work, including adding DNS to allow us to resolve the database server's URL. 