### PR TITLE
Patch/event notification channels

### DIFF
--- a/src/lib/schema/events/attendees.ts
+++ b/src/lib/schema/events/attendees.ts
@@ -39,7 +39,7 @@ export const create = v.object({
 	status: v.optional(base.entries.status, 'registered'),
 	notes: v.optional(base.entries.notes),
 	send_notifications: v.optional(base.entries.send_notifications, true),
-	response_channel: v.optional(v.union([v.literal('email'), v.literal('whatsapp')]), 'email')
+	response_channel: v.optional(v.picklist(['whatsapp', 'email', 'none']), 'email')
 });
 export type Create = v.InferOutput<typeof create>;
 

--- a/src/routes/(api)/worker/imports/people/[import_id]/+server.ts
+++ b/src/routes/(api)/worker/imports/people/[import_id]/+server.ts
@@ -239,7 +239,8 @@ async function addPersonToEvent({
 				person_id: personId,
 				status: 'attended',
 				send_notifications: false,
-				notes: `import:${importId}`
+				notes: `import:${importId}`,
+				response_channel: 'none'
 			},
 			t,
 			queue


### PR DESCRIPTION
This is a tiny patch to create a `none` response channel for event attendee objects. Previously the only options were `email` or `whatsapp`. 

This is only relevant when registering a new attendance, and is used to determine whether the autoresponse registration notification should come via email or whatsapp. However, in cases where we aren't going to be sending a notification anyway (because `send_notifications` is set to false) we should have a value which makes sense in terms of reading the code and doesn't case typescript errors :) 