### PR TITLE
Hide "Filter" input if there are no uploads

### DIFF
--- a/src/lib/comps/widgets/uploads/UploadWidget.svelte
+++ b/src/lib/comps/widgets/uploads/UploadWidget.svelte
@@ -90,15 +90,13 @@
 			}}
 		/>
 
-		<Separator class="my-4" />
-
-		<Input
-			placeholder={m.proud_kind_sloth_feel()}
-			bind:value={filter}
-			oninput={debounce(reload, 400)}
-		/>
-
 		{#if list.count > 0}
+			<Separator class="my-4" />
+			<Input
+				placeholder={m.proud_kind_sloth_feel()}
+				bind:value={filter}
+				oninput={debounce(reload, 400)}
+			/>
 			<div
 				class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 lg:gap-6 mt-4"
 			>


### PR DESCRIPTION
If there are zero uploads we don't need to filter anything, so there's no need for the input to display. Previously, if there were zero uploads this would show as a weird input without context and was confusing.