### PR TITLE
Add check for unfilled placeholders in whatsapp message

### DIFF
--- a/src/lib/comps/forms/whatsapp/messages/builder/actions/components.test.ts
+++ b/src/lib/comps/forms/whatsapp/messages/builder/actions/components.test.ts
@@ -6,7 +6,8 @@ import {
 	extractComponents,
 	countTextTemplatePlaceholders,
 	extractTemplateMessageComponents,
-	createMessageComponentsFromTemplateComponents
+	createMessageComponentsFromTemplateComponents,
+	hasUnfilledPlaceholders
 } from '$lib/comps/forms/whatsapp/messages/builder/actions/components';
 
 // Sample test data
@@ -202,5 +203,127 @@ describe('createMessageComponentsFromTemplateComponents', () => {
 			threadMessage
 		);
 		expect(result.components.length).toBe(0);
+	});
+});
+
+describe('hasUnfilledPlaceholders', () => {
+	it('should return false when template is null', () => {
+		expect(hasUnfilledPlaceholders(null, [], { type: 'template' })).toBe(false);
+	});
+
+	it('should return false when message is not template type', () => {
+		expect(hasUnfilledPlaceholders({}, [], { type: 'text' })).toBe(false);
+	});
+
+	it('should return true when header has unfilled placeholders', () => {
+		const template = {
+			message: {
+				components: [
+					{
+						type: 'HEADER',
+						format: 'TEXT',
+						text: 'Hello {{1}}'
+					}
+				]
+			}
+		};
+		const components = [
+			{
+				type: 'header',
+				parameters: []
+			}
+		];
+		expect(hasUnfilledPlaceholders(template, components, { type: 'template' })).toBe(true);
+	});
+
+	it('should return true when body has unfilled placeholders', () => {
+		const template = {
+			message: {
+				components: [
+					{
+						type: 'BODY',
+						format: 'TEXT',
+						text: 'Message {{1}}'
+					}
+				]
+			}
+		};
+		const components = [
+			{
+				type: 'body',
+				parameters: []
+			}
+		];
+		expect(hasUnfilledPlaceholders(template, components, { type: 'template' })).toBe(true);
+	});
+
+	it('should return true when placeholder text still exists in parameters', () => {
+		const template = {
+			message: {
+				components: [
+					{
+						type: 'BODY',
+						format: 'TEXT',
+						text: 'Message {{1}}'
+					}
+				]
+			}
+		};
+		const components = [
+			{
+				type: 'body',
+				parameters: [
+					{
+						type: 'text',
+						text: '{{1}}'
+					}
+				]
+			}
+		];
+		expect(hasUnfilledPlaceholders(template, components, { type: 'template' })).toBe(true);
+	});
+
+	it('should return false when all placeholders are filled', () => {
+		const template = {
+			message: {
+				components: [
+					{
+						type: 'HEADER',
+						format: 'TEXT',
+						text: 'Hello {{1}}'
+					},
+					{
+						type: 'BODY',
+						format: 'TEXT',
+						text: 'Message {{1}} and {{2}}'
+					}
+				]
+			}
+		};
+		const components = [
+			{
+				type: 'header',
+				parameters: [
+					{
+						type: 'text',
+						text: 'John'
+					}
+				]
+			},
+			{
+				type: 'body',
+				parameters: [
+					{
+						type: 'text',
+						text: 'John'
+					},
+					{
+						type: 'text',
+						text: 'Doe'
+					}
+				]
+			}
+		];
+		expect(hasUnfilledPlaceholders(template, components, { type: 'template' })).toBe(false);
 	});
 });

--- a/src/lib/comps/forms/whatsapp/messages/builder/actions/components.ts
+++ b/src/lib/comps/forms/whatsapp/messages/builder/actions/components.ts
@@ -224,3 +224,39 @@ export function createMessageComponentsFromTemplateComponents(
 	}
 	return { components, actions: actionsObject };
 }
+
+export function hasUnfilledPlaceholders(
+	template: any | null,
+	components: any[],
+	templateMessage: { type: string }
+) {
+	if (!template || templateMessage.type !== 'template') return false;
+
+	// Check header
+	const headerComponent = template.message.components.find(
+		(comp: any) => comp.type === 'HEADER' && comp.format === 'TEXT'
+	);
+	if (headerComponent && 'text' in headerComponent) {
+		const headerPlaceholders = countTextTemplatePlaceholders(headerComponent.text);
+		const headerParams = components.find((comp) => comp.type === 'header')?.parameters || [];
+		if (headerPlaceholders > headerParams.length) return true;
+
+		for (const param of headerParams) {
+			if (param.type === 'text' && /{{[0-9]+}}/.test(param.text)) return true;
+		}
+	}
+
+	// Check body
+	const bodyComponent = template.message.components.find((comp: any) => comp.type === 'BODY');
+	if (bodyComponent && 'text' in bodyComponent) {
+		const bodyPlaceholders = countTextTemplatePlaceholders(bodyComponent.text);
+		const bodyParams = components.find((comp) => comp.type === 'body')?.parameters || [];
+		if (bodyPlaceholders > bodyParams.length) return true;
+
+		for (const param of bodyParams) {
+			if (param.type === 'text' && /{{[0-9]+}}/.test(param.text)) return true;
+		}
+	}
+
+	return false;
+}

--- a/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
+++ b/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
@@ -97,42 +97,8 @@
 	import * as m from '$lib/paraglide/messages';
 	import { goto } from '$app/navigation';
 
-	import { countTextTemplatePlaceholders } from '$lib/comps/forms/whatsapp/messages/builder/actions/components';
-
-	function hasUnfilledPlaceholders() {
-		if (!template || templateMessage.type !== 'template') return false;
-
-		// Check header
-		const headerComponent = template.message.components.find(
-			(comp) => comp.type === 'HEADER' && comp.format === 'TEXT'
-		);
-		if (headerComponent && 'text' in headerComponent) {
-			const headerPlaceholders = countTextTemplatePlaceholders(headerComponent.text);
-			const headerParams = components.find((comp) => comp.type === 'header')?.parameters || [];
-			if (headerPlaceholders > headerParams.length) return true;
-
-			for (const param of headerParams) {
-				if (param.type === 'text' && /{{[0-9]+}}/.test(param.text)) return true;
-			}
-		}
-
-		// Check body
-		const bodyComponent = template.message.components.find((comp) => comp.type === 'BODY');
-		if (bodyComponent && 'text' in bodyComponent) {
-			const bodyPlaceholders = countTextTemplatePlaceholders(bodyComponent.text);
-			const bodyParams = components.find((comp) => comp.type === 'body')?.parameters || [];
-			if (bodyPlaceholders > bodyParams.length) return true;
-
-			for (const param of bodyParams) {
-				if (param.type === 'text' && /{{[0-9]+}}/.test(param.text)) return true;
-			}
-		}
-
-		return false;
-	}
-
 	async function handleSendClick() {
-		if (hasUnfilledPlaceholders()) {
+		if (componentActions.hasUnfilledPlaceholders(template, components, templateMessage)) {
 			$flash = { type: 'error', message: 'Please fill in all placeholders before sending' };
 			return;
 		}


### PR DESCRIPTION
This prevents sending of whatsapp messages if some of the `{{1}}` placeholders have not been edited