### PR TITLE
Feature/onboarding form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
 				"husky": "^9.1.7",
 				"isomorphic-dompurify": "^2.20.0",
 				"javascript-time-ago": "^2.5.10",
+				"jose": "^6.0.11",
 				"knex": "^3.1.0",
 				"letterparser": "^0.1.8",
 				"node-pg-format": "^1.3.5",
@@ -10181,6 +10182,15 @@
 				"@sideway/address": "^4.1.5",
 				"@sideway/formula": "^3.0.1",
 				"@sideway/pinpoint": "^2.0.0"
+			}
+		},
+		"node_modules/jose": {
+			"version": "6.0.11",
+			"resolved": "https://registry.npmjs.org/jose/-/jose-6.0.11.tgz",
+			"integrity": "sha512-QxG7EaliDARm1O1S8BGakqncGT9s25bKL1WSf6/oa17Tkqwi8D2ZNglqCF+DsYF88/rV66Q/Q2mFAy697E1DUg==",
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/panva"
 			}
 		},
 		"node_modules/js-sha256": {

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
 		"husky": "^9.1.7",
 		"isomorphic-dompurify": "^2.20.0",
 		"javascript-time-ago": "^2.5.10",
+		"jose": "^6.0.11",
 		"knex": "^3.1.0",
 		"letterparser": "^0.1.8",
 		"node-pg-format": "^1.3.5",

--- a/src/lib/schema/core/admin.ts
+++ b/src/lib/schema/core/admin.ts
@@ -12,6 +12,7 @@ import {
 	url,
 	uuid
 } from '$lib/schema/valibot';
+import { fullName } from '../people/filters/defaults';
 
 export const base = v.object({
 	id: id,
@@ -77,9 +78,13 @@ export const list = v.object({
 
 export type List = v.InferOutput<typeof list>;
 
-export const create = v.pick(base, ['email', 'full_name']);
+export const create = v.object({
+	email: base.entries.email,
+	full_name: base.entries.full_name,
+	profile_picture_url: v.optional(base.entries.profile_picture_url, null)
+});
 
-export type Create = v.InferOutput<typeof create>;
+export type Create = v.InferInput<typeof create>;
 
 export const readApiKey = v.pick(base, ['api_key']);
 

--- a/src/lib/server/api/core/admins.ts
+++ b/src/lib/server/api/core/admins.ts
@@ -328,3 +328,13 @@ export async function del({
 	await redis.del(redisString(instance_id, admin_id));
 	await redis.del(redisString(instance_id, 'all'));
 }
+
+export async function _unsafeGetAdminByEmail({ email }: { email: string }): Promise<schema.Read> {
+	const response = await db
+		.selectExactlyOne('admins', { email, deleted_at: db.conditions.isNull })
+		.run(pool)
+		.catch((err: Error) => {
+			throw new BelcodaError(404, 'DATA:CORE:ADMINS:READ:01', m.pretty_tired_fly_lead(), err);
+		});
+	return v.parse(schema.read, response);
+}

--- a/src/lib/server/api/core/admins.ts
+++ b/src/lib/server/api/core/admins.ts
@@ -128,10 +128,8 @@ export async function update({
 }
 
 export async function signIn({
-	t,
 	body
 }: {
-	t: App.Localization;
 	body: schema.SignIn;
 }): Promise<{ admin: schema.Read; session: string }> {
 	const parsed = v.parse(schema.signIn, body);

--- a/src/lib/server/hooks/handlers.ts
+++ b/src/lib/server/hooks/handlers.ts
@@ -20,6 +20,11 @@ export type HandlerResponse =
 
 type Resolve = (event: RequestEvent, opts?: ResolveOptions | undefined) => Promise<Response>;
 export default async function (event: RequestEvent, resolve: Resolve): Promise<HandlerResponse> {
+	if (event.url.pathname.startsWith('/onboarding')) {
+		log.info(`🌎 ${event.request.method} ${event.url.href}`);
+		return await { continue: false, response: await resolve(event) };
+	}
+
 	if (event.url.pathname.startsWith('/webhooks/email')) {
 		log.info(`🌎 ${event.request.method} ${event.url.href}`);
 		return await emailHandler(event, resolve);

--- a/src/lib/server/utils/install/index.ts
+++ b/src/lib/server/utils/install/index.ts
@@ -16,6 +16,7 @@ export type InstallOptions = {
 	instanceSlug: string;
 	ownerEmail: string;
 	ownerName: string;
+	ownerProfilePictureUrl?: string;
 	logoUrl: string;
 	faviconUrl?: string;
 	country: SupportedCountry;
@@ -67,7 +68,11 @@ export default async function install(
 	log.debug(`instance ${instance.id} created`);
 	const admin = await createAdmin({
 		instance_id: instance.id,
-		body: { email: options.ownerEmail, full_name: options.ownerName },
+		body: {
+			email: options.ownerEmail,
+			full_name: options.ownerName,
+			profile_picture_url: options.ownerProfilePictureUrl
+		},
 		queue
 	});
 	log.debug(`admin ${admin.id} created`);

--- a/src/routes/(utility)/auth/google/+server.ts
+++ b/src/routes/(utility)/auth/google/+server.ts
@@ -22,7 +22,6 @@ export const POST = async function (event) {
 		const signInDetails = await verify(credential);
 		const parsedSignInDetails = parse(validateSignIn, signInDetails);
 		const { session, admin } = await signIn({
-			t: new Localization(event.locals.language),
 			body: parsedSignInDetails
 		});
 

--- a/src/routes/(utility)/onboarding/+layout.svelte
+++ b/src/routes/(utility)/onboarding/+layout.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+	const { data, children } = $props();
+</script>
+
+<svelte:head><title>Belcoda - New organization onboarding</title></svelte:head>
+<div class="min-h-screen w-full bg-gradient-to-br from-slate-300 to-stone-300 text-gray-600">
+	<div class="mx-auto max-w-lg p-6 rounded-lg bg-gray-50 shadow-lg my-12">
+		{@render children()}
+	</div>
+</div>

--- a/src/routes/(utility)/onboarding/+page.server.ts
+++ b/src/routes/(utility)/onboarding/+page.server.ts
@@ -1,0 +1,6 @@
+export const load = async (event) => {
+	event.setHeaders({
+		'Cross-Origin-Opener-Policy': 'same-origin-allow-popups'
+	});
+	return {};
+};

--- a/src/routes/(utility)/onboarding/+page.svelte
+++ b/src/routes/(utility)/onboarding/+page.svelte
@@ -2,6 +2,8 @@
 	import { PUBLIC_HOST, PUBLIC_GOOGLE_AUTH_CLIENT_ID } from '$env/static/public';
 	// Update the login_uri to include the continue parameter if it exists
 	const loginUri = `${PUBLIC_HOST}/onboarding/auth/google`;
+	import { page } from '$app/state';
+	const error = page.url.searchParams.get('error') === 'true';
 </script>
 
 <svelte:head>
@@ -11,6 +13,19 @@
 
 <div class="grid grid-cols-1 gap-3">
 	<h1 class="text-3xl lg:text-4xl font-extrabold text-gray-800">Welcome to Belcoda</h1>
+	{#if error}
+		<div
+			class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+			role="alert"
+		>
+			<strong class="font-bold">Error:</strong>
+			<span class="block sm:inline"
+				>We weren't able to create an account. The most common reason is that the email address of
+				your Google Account already has an account account on Belcoda. If you're not sure, please
+				try again with a different Google Account you have access to.</span
+			>
+		</div>
+	{/if}
 	<p class=" text-gray-600 text-base lg:text-lg">
 		In order to get started, we need to ask you a few questions about you and your organization.
 	</p>

--- a/src/routes/(utility)/onboarding/+page.svelte
+++ b/src/routes/(utility)/onboarding/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
 	import { PUBLIC_HOST, PUBLIC_GOOGLE_AUTH_CLIENT_ID } from '$env/static/public';
-	import * as m from '$lib/paraglide/messages';
 	// Update the login_uri to include the continue parameter if it exists
 	const loginUri = `${PUBLIC_HOST}/onboarding/auth/google`;
 </script>

--- a/src/routes/(utility)/onboarding/+page.svelte
+++ b/src/routes/(utility)/onboarding/+page.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { PUBLIC_HOST, PUBLIC_GOOGLE_AUTH_CLIENT_ID } from '$env/static/public';
+	import * as m from '$lib/paraglide/messages';
+	// Update the login_uri to include the continue parameter if it exists
+	const loginUri = `${PUBLIC_HOST}/onboarding/auth/google`;
+</script>
+
+<svelte:head>
+	<title>Belcoda - Start onboarding</title>
+	<script src="https://accounts.google.com/gsi/client" async></script>
+</svelte:head>
+
+<div class="grid grid-cols-1 gap-3">
+	<h1 class="text-3xl lg:text-4xl font-extrabold text-gray-800">Welcome to Belcoda</h1>
+	<p class=" text-gray-600 text-base lg:text-lg">
+		In order to get started, we need to ask you a few questions about you and your organization.
+	</p>
+	<p class=" text-gray-600 text-base lg:text-lg">
+		Then, the system will automatically create a new organization for you, and you will be
+		redirected to the organization dashboard.
+	</p>
+	<p class=" text-gray-600 text-base lg:text-lg">
+		But before we continue, you need to create an account on Belcoda using your Google account.
+	</p>
+	<p class=" text-gray-600 text-base lg:text-lg">
+		At the moment, Login With Google is the only way to login to the Belcoda platform, so you will
+		need a Google account to continue.
+	</p>
+	<div class="flex justify-start my-4">
+		<div
+			id="g_id_onload"
+			data-client_id={PUBLIC_GOOGLE_AUTH_CLIENT_ID}
+			data-context="signin"
+			data-ux_mode="popup"
+			data-login_uri={loginUri}
+			data-auto_prompt="false"
+		></div>
+
+		<div
+			class="g_id_signin"
+			data-type="standard"
+			data-shape="rectangular"
+			data-theme="default"
+			data-text="continue_with"
+			data-size="large"
+			data-logo_alignment="left"
+		></div>
+	</div>
+</div>

--- a/src/routes/(utility)/onboarding/auth/google/+server.ts
+++ b/src/routes/(utility)/onboarding/auth/google/+server.ts
@@ -4,27 +4,35 @@ import { verify } from '../../../auth/google/verifyIdToken';
 import { dev } from '$app/environment';
 import { redirect } from '@sveltejs/kit';
 
+import { _unsafeGetAdminByEmail } from '$lib/server/api/core/admins';
+
 export async function POST(event) {
-	const tokenCookie = event.cookies.get('g_csrf_token');
-	const body = await event.request.formData();
-	const tokenBody = body.get('g_csrf_token');
-	const credential = body.get('credential');
-	if (!tokenCookie) throw new Error('CSRF token not found in request headers');
-	if (!tokenBody) throw new Error('CSRF token not found in request body');
-	if (tokenCookie !== tokenBody) throw new Error('Token mismatch. Unable to authenticate.');
-	if (typeof credential !== 'string') throw new Error('Invalid credential');
-	const jwt = await createJwt(credential);
-	// Set the session cookie to expire in 2 weeks
-	const today = new Date();
-	const expires = new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000);
-	event.cookies.set(JWT_NAME, jwt, {
-		path: '/',
-		expires: expires,
-		httpOnly: true,
-		secure: dev ? false : true,
-		sameSite: 'strict'
-	});
-	return redirect(302, '/onboarding/survey');
+	try {
+		const tokenCookie = event.cookies.get('g_csrf_token');
+		const body = await event.request.formData();
+		const tokenBody = body.get('g_csrf_token');
+		const credential = body.get('credential');
+		if (!tokenCookie) throw new Error('CSRF token not found in request headers');
+		if (!tokenBody) throw new Error('CSRF token not found in request body');
+		if (tokenCookie !== tokenBody) throw new Error('Token mismatch. Unable to authenticate.');
+		if (typeof credential !== 'string') throw new Error('Invalid credential');
+		const jwt = await createJwt(credential);
+		// Set the session cookie to expire in 2 weeks
+		const today = new Date();
+		const expires = new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000);
+		event.cookies.set(JWT_NAME, jwt, {
+			path: '/',
+			expires: expires,
+			httpOnly: true,
+			secure: dev ? false : true,
+			sameSite: 'strict'
+		});
+
+		return redirect(302, '/onboarding/survey');
+	} catch (error) {
+		console.error('Error during authentication:', error);
+		return redirect(302, '/onboarding?error=true');
+	}
 }
 
 async function createJwt(token: string) {
@@ -33,6 +41,17 @@ async function createJwt(token: string) {
 	if (!signInDetails || !signInDetails.email) {
 		throw new Error('Invalid sign-in details');
 	}
+
+	// Check if the email address is already in use
+	const existingUser = await _unsafeGetAdminByEmail({ email: signInDetails.email }).catch((err) => {
+		// No need to handle the error here, just return null, we're happy with no user existing, that means we continue
+		return null;
+	});
+
+	if (existingUser) {
+		throw new Error('Email address already in use');
+	}
+
 	const jwt = await new jose.SignJWT({
 		roles: signInDetails.full_name,
 		typ: signInDetails.google_token_type,

--- a/src/routes/(utility)/onboarding/auth/google/+server.ts
+++ b/src/routes/(utility)/onboarding/auth/google/+server.ts
@@ -1,0 +1,58 @@
+import * as jose from 'jose';
+import { JWT_SIGNING_SECRET } from '$env/static/private';
+import { verify } from '../../../auth/google/verifyIdToken';
+import { json } from '@sveltejs/kit';
+export async function POST(event) {
+	const tokenCookie = event.cookies.get('g_csrf_token');
+	const body = await event.request.formData();
+	const tokenBody = body.get('g_csrf_token');
+	const credential = body.get('credential');
+	if (!tokenCookie) throw new Error('CSRF token not found in request headers');
+	if (!tokenBody) throw new Error('CSRF token not found in request body');
+	if (tokenCookie !== tokenBody) throw new Error('Token mismatch. Unable to authenticate.');
+	if (typeof credential !== 'string') throw new Error('Invalid credential');
+	const jwt = await createJwt(credential);
+	return json(jwt);
+}
+
+async function createJwt(token: string) {
+	const secret = new TextEncoder().encode(must(JWT_SIGNING_SECRET));
+	const signInDetails = await verify(token);
+	if (!signInDetails || !signInDetails.email) {
+		throw new Error('Invalid sign-in details');
+	}
+	const jwt = await new jose.SignJWT({
+		roles: signInDetails.full_name,
+		typ: signInDetails.google_token_type,
+		exp: Number(signInDetails.google_expires_in),
+		aud: signInDetails.google_id,
+		ueid: signInDetails.full_name,
+		email: signInDetails.email,
+		sub_id: signInDetails.profile_picture_url
+	})
+		.setProtectedHeader({ alg: 'HS256' })
+		.setIssuedAt()
+		.setIssuer('urn:example:issuer')
+		.setSubject(signInDetails.google_access_token)
+		.setAudience('urn:example:audience')
+		.setExpirationTime('30days')
+		.sign(secret);
+
+	const parsed = await jose
+		.jwtVerify(jwt, secret, {
+			issuer: 'urn:example:issuer',
+			audience: 'urn:example:audience'
+		})
+		.catch((err) => {
+			console.error('Error verifying JWT', err);
+			throw new Error('Unable to verify JWT. ' + err.message);
+		});
+
+	return jwt;
+}
+function must<T>(val: T) {
+	if (!val) {
+		throw new Error('Expected value to be defined');
+	}
+	return val;
+}

--- a/src/routes/(utility)/onboarding/survey/+page.server.ts
+++ b/src/routes/(utility)/onboarding/survey/+page.server.ts
@@ -1,0 +1,15 @@
+import { redirect } from '@sveltejs/kit';
+import * as jose from 'jose';
+import { JWT_SIGNING_SECRET, JWT_NAME, COOKIE_SESSION_NAME } from '$env/static/private';
+export async function load(event) {
+	try {
+		const jwt = event.cookies.get(JWT_NAME);
+		if (!jwt) throw new Error('JWT not found in cookies');
+		const validatedJwt = await jose.jwtVerify(jwt, new TextEncoder().encode(JWT_SIGNING_SECRET));
+		if (!validatedJwt) throw new Error('JWT not valid');
+		return {};
+	} catch (err) {
+		console.error('Error validating JWT:', err);
+		return redirect(302, '/onboarding');
+	}
+}

--- a/src/routes/(utility)/onboarding/survey/+page.svelte
+++ b/src/routes/(utility)/onboarding/survey/+page.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+	const { data: pageData } = $props();
+	import createForm from './form.svelte';
+	import TextInput from './TextInput.svelte';
+	import CountrySelect from './CountrySelect.svelte';
+	import SuperDebug from 'sveltekit-superforms';
+	const { form, data, warnBeforeDiscard } = createForm({
+		onSubmit: async (formData) => {
+			// Handle form submission
+			console.log('Form submitted:', formData);
+		}
+	});
+</script>
+
+<form method="POST" use:form.enhance class="grid grid-cols-1 gap-3">
+	{@render H1('Onboarding survey')}
+	<p>
+		Before we get started, I need to ask a few questions in order to set up your organization on the
+		Belcoda platform.
+	</p>
+	<p>Please read the questions carefully and provide answers to all the ones you can.</p>
+	{@render H2('A little bit about you')}
+	<p>
+		These questions are about you, the person who is setting up this organization on Belcoda. You
+		will be the first user for your organization, but you can add other users later.
+	</p>
+	<TextInput
+		superform={form}
+		field="ownerName"
+		label="Your full name"
+		description="This is the name that will be displayed on your profile."
+	/>
+	<TextInput
+		superform={form}
+		type="email"
+		field="whatsAppNumber"
+		label="WhatsApp number"
+		description="What's the best phone number to reach you on WhatsApp? Please use the full international format, including the country code. For example, +15551234567."
+	/>
+
+	{@render H2('About your organization')}
+	<p>
+		We need a bit of information about your organization in order to get you set up with the correct
+		settings.
+	</p>
+	<TextInput
+		class="mb-3"
+		superform={form}
+		type="text"
+		field="instanceName"
+		label="Your organization's name"
+	/>
+	<TextInput
+		superform={form}
+		type="text"
+		field="instanceSlug"
+		label="A short, URL-friendly version of your organization's name"
+		description="This will be part of the domain name for your organization's event and other pages hosted on Belcoda. No spaces or special characters are allowed. Only lowercase letters from the English alphabet, numbers and underscores (_)"
+	/>
+	<CountrySelect
+		superform={form}
+		field="country"
+		label="Country"
+		description="The country in which your organization is based. If you operate in multiple countries, then choose the country that you yourself reside in."
+	/>
+	{@render H2('A quick question about email')}
+	<p>
+		By default, email sent via Belcoda (for example, event invitations or reminder messages) will be
+		appear from:
+	</p>
+	<p>
+		<code
+			>{$data.instanceName || 'Instance Name'}
+			{`<${$data.instanceSlug || 'instance_slug'}@belcoda.com>`}</code
+		>
+	</p>
+	<p>
+		When someone replies to one of those emails, which email address do you want to receive the
+		replies at? It should be an email address you check regularly.
+	</p>
+	<TextInput
+		superform={form}
+		type="email"
+		field="replyToEmail"
+		label="Default reply-to email"
+		description="Which email address should we direct incoming email messages to? Don't worry, you can change all these settings later."
+	/>
+	{@render H2('Where else is your organization available online?')}
+	<p>
+		If you don't have an account on all these platforms, it's totally fine to leave these blank.
+	</p>
+	<TextInput
+		superform={form}
+		type="text"
+		field="website"
+		label="Website"
+		description="The URL of your organization's website (leave blank if you don't have one)."
+	/>
+	<TextInput
+		superform={form}
+		type="text"
+		field="facebook"
+		label="Facebook"
+		description="The URL of your organization's Facebook page"
+	/>
+	<TextInput
+		superform={form}
+		type="text"
+		field="twitter"
+		label="Twitter/X"
+		description="Your organization's Twitter/X account"
+	/>
+	<TextInput
+		superform={form}
+		type="text"
+		field="instagram"
+		label="Instagram"
+		description="Your organization's Instagram account"
+	/>
+	<div>
+		<button
+			type="submit"
+			class="w-full mt-4 inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+		>
+			Continue
+		</button>
+	</div>
+	<SuperDebug data={$data} />
+</form>
+
+{#snippet H1(text: string)}
+	<h1 class="text-3xl lg:text-4xl font-extrabold text-gray-800">{text}</h1>
+{/snippet}
+
+{#snippet H2(text: string)}
+	<h2 class="text-2xl lg:text-3xl font-extrabold text-gray-800 mt-4">{text}</h2>
+{/snippet}

--- a/src/routes/(utility)/onboarding/survey/+page.svelte
+++ b/src/routes/(utility)/onboarding/survey/+page.svelte
@@ -7,9 +7,11 @@
 	import Loading from '$lib/comps/helpers/Loading.svelte';
 	import { dev } from '$app/environment';
 	import { goto } from '$app/navigation';
+	let error = $state(false);
 	const { form, data, warnBeforeDiscard, capture, restore } = createForm({
 		onSubmit: async (formData) => {
 			try {
+				error = false;
 				loading = true;
 				const response = await fetch('/onboarding/survey/onboard', {
 					method: 'POST',
@@ -23,6 +25,7 @@
 				}
 				await goto('/');
 			} catch (error) {
+				error = true;
 				console.error('Error submitting form:', error);
 			} finally {
 				loading = false;
@@ -45,6 +48,18 @@
 		</div>
 	</div>
 {:else}
+	{#if error}
+		<div
+			class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative"
+			role="alert"
+		>
+			<strong class="font-bold">Error:</strong>
+			<span class="block sm:inline">
+				We weren't able to create an account. You can try again, but if this keeps happening, please
+				get in touch with the support team.
+			</span>
+		</div>
+	{/if}
 	<form method="POST" use:form.enhance class="grid grid-cols-1 gap-3">
 		{@render H1('Onboarding survey')}
 		<p>

--- a/src/routes/(utility)/onboarding/survey/+page.svelte
+++ b/src/routes/(utility)/onboarding/survey/+page.svelte
@@ -1,132 +1,177 @@
 <script lang="ts">
-	const { data: pageData } = $props();
 	import createForm from './form.svelte';
 	import TextInput from './TextInput.svelte';
 	import CountrySelect from './CountrySelect.svelte';
 	import SuperDebug from 'sveltekit-superforms';
-	const { form, data, warnBeforeDiscard } = createForm({
+	import { PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME } from '$env/static/public';
+	import Loading from '$lib/comps/helpers/Loading.svelte';
+	import { dev } from '$app/environment';
+	import { goto } from '$app/navigation';
+	const { form, data, warnBeforeDiscard, capture, restore } = createForm({
 		onSubmit: async (formData) => {
-			// Handle form submission
-			console.log('Form submitted:', formData);
+			try {
+				loading = true;
+				const response = await fetch('/onboarding/survey/onboard', {
+					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json'
+					},
+					body: JSON.stringify(formData)
+				});
+				if (!response.ok) {
+					throw new Error(await response.text());
+				}
+				await goto('/');
+			} catch (error) {
+				console.error('Error submitting form:', error);
+			} finally {
+				loading = false;
+			}
 		}
 	});
+	export const snapshot = { capture, restore }; // This will make sure that the form is saved and restored when using browser back/forward buttons
+	import FileUpload from '$lib/comps/ui/form/controls/file_upload/simple_file_upload.svelte';
+	let loading = $state(false);
 </script>
 
-<form method="POST" use:form.enhance class="grid grid-cols-1 gap-3">
-	{@render H1('Onboarding survey')}
-	<p>
-		Before we get started, I need to ask a few questions in order to set up your organization on the
-		Belcoda platform.
-	</p>
-	<p>Please read the questions carefully and provide answers to all the ones you can.</p>
-	{@render H2('A little bit about you')}
-	<p>
-		These questions are about you, the person who is setting up this organization on Belcoda. You
-		will be the first user for your organization, but you can add other users later.
-	</p>
-	<TextInput
-		superform={form}
-		field="ownerName"
-		label="Your full name"
-		description="This is the name that will be displayed on your profile."
-	/>
-	<TextInput
-		superform={form}
-		type="email"
-		field="whatsAppNumber"
-		label="WhatsApp number"
-		description="What's the best phone number to reach you on WhatsApp? Please use the full international format, including the country code. For example, +15551234567."
-	/>
-
-	{@render H2('About your organization')}
-	<p>
-		We need a bit of information about your organization in order to get you set up with the correct
-		settings.
-	</p>
-	<TextInput
-		class="mb-3"
-		superform={form}
-		type="text"
-		field="instanceName"
-		label="Your organization's name"
-	/>
-	<TextInput
-		superform={form}
-		type="text"
-		field="instanceSlug"
-		label="A short, URL-friendly version of your organization's name"
-		description="This will be part of the domain name for your organization's event and other pages hosted on Belcoda. No spaces or special characters are allowed. Only lowercase letters from the English alphabet, numbers and underscores (_)"
-	/>
-	<CountrySelect
-		superform={form}
-		field="country"
-		label="Country"
-		description="The country in which your organization is based. If you operate in multiple countries, then choose the country that you yourself reside in."
-	/>
-	{@render H2('A quick question about email')}
-	<p>
-		By default, email sent via Belcoda (for example, event invitations or reminder messages) will be
-		appear from:
-	</p>
-	<p>
-		<code
-			>{$data.instanceName || 'Instance Name'}
-			{`<${$data.instanceSlug || 'instance_slug'}@belcoda.com>`}</code
-		>
-	</p>
-	<p>
-		When someone replies to one of those emails, which email address do you want to receive the
-		replies at? It should be an email address you check regularly.
-	</p>
-	<TextInput
-		superform={form}
-		type="email"
-		field="replyToEmail"
-		label="Default reply-to email"
-		description="Which email address should we direct incoming email messages to? Don't worry, you can change all these settings later."
-	/>
-	{@render H2('Where else is your organization available online?')}
-	<p>
-		If you don't have an account on all these platforms, it's totally fine to leave these blank.
-	</p>
-	<TextInput
-		superform={form}
-		type="text"
-		field="website"
-		label="Website"
-		description="The URL of your organization's website (leave blank if you don't have one)."
-	/>
-	<TextInput
-		superform={form}
-		type="text"
-		field="facebook"
-		label="Facebook"
-		description="The URL of your organization's Facebook page"
-	/>
-	<TextInput
-		superform={form}
-		type="text"
-		field="twitter"
-		label="Twitter/X"
-		description="Your organization's Twitter/X account"
-	/>
-	<TextInput
-		superform={form}
-		type="text"
-		field="instagram"
-		label="Instagram"
-		description="Your organization's Instagram account"
-	/>
-	<div>
-		<button
-			type="submit"
-			class="w-full mt-4 inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-		>
-			Continue
-		</button>
+{#if loading}
+	<div class="flex justify-center items-center my-20">
+		<div>
+			<Loading />
+			<div class="text-center font-medium">Setting up your organization...</div>
+			<div class="text-sm mt-1 text-center text-gray-500">
+				This can take a few seconds. Please don't close this page.
+			</div>
+		</div>
 	</div>
-	<SuperDebug data={$data} />
-</form>
+{:else}
+	<form method="POST" use:form.enhance class="grid grid-cols-1 gap-3">
+		{@render H1('Onboarding survey')}
+		<p>
+			Before we get started, I need to ask a few questions in order to set up your organization on
+			the Belcoda platform.
+		</p>
+		<p>Please read the questions carefully and provide answers to all the ones you can.</p>
+		{@render H2('A little bit about you')}
+		<p>
+			These questions are about you, the person who is setting up this organization on Belcoda. You
+			will be the first user for your organization, but you can add other users later.
+		</p>
+		<TextInput
+			superform={form}
+			field="ownerName"
+			label="Your full name"
+			description="This is the name that will be displayed on your profile."
+		/>
+		<TextInput
+			superform={form}
+			field="whatsAppNumber"
+			label="WhatsApp number"
+			description="What's the best phone number to reach you on WhatsApp? Please use the full international format, including the country code. For example, +15551234567."
+		/>
+
+		{@render H2('About your organization')}
+		<p>
+			We need a bit of information about your organization in order to get you set up with the
+			correct settings.
+		</p>
+		<TextInput
+			class="mb-3"
+			superform={form}
+			type="text"
+			field="instanceName"
+			label="Your organization's name"
+		/>
+		<TextInput
+			superform={form}
+			type="text"
+			field="instanceSlug"
+			label="A short, URL-friendly version of your organization's name"
+			description="This will be part of the domain name for your organization's event and other pages hosted on Belcoda. No spaces or special characters are allowed. Only lowercase letters from the English alphabet, numbers and underscores (_)"
+		/>
+		<div class="font-medium text-gray-800 text-sm -mb-2">Your organization's logo</div>
+		<FileUpload
+			description="Please upload a logo for your organization. This will be used on your event and other website pages. It must be under 5MB in size and in PNG or JPG format."
+			bucketName={PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME}
+			siteUploadsUrl="/onboarding/survey/upload"
+			fileTypes={['image/png', 'image/jpeg', 'image/jpg']}
+			maxSize={5 * 1024 * 1024}
+			onUpload={({ url }) => {
+				console.log('Uploaded file URL:', url);
+				$data.instanceLogoUrl = url;
+			}}
+		/>
+		<CountrySelect
+			superform={form}
+			field="country"
+			label="Country"
+			description="The country in which your organization is based. If you operate in multiple countries, then choose the country that you yourself reside in."
+		/>
+		{@render H2('A quick question about email')}
+		<p>
+			By default, email sent via Belcoda (for example, event invitations or reminder messages) will
+			be appear from:
+		</p>
+		<p>
+			<code
+				>{$data.instanceName || 'Instance Name'}
+				{`<${$data.instanceSlug || 'instance_slug'}@belcoda.com>`}</code
+			>
+		</p>
+		<p>
+			When someone replies to one of those emails, which email address do you want to receive the
+			replies at? It should be an email address you check regularly.
+		</p>
+		<TextInput
+			superform={form}
+			type="email"
+			field="replyToEmail"
+			label="Default reply-to email"
+			description="Which email address should we direct incoming email messages to? Don't worry, you can change all these settings later."
+		/>
+		{@render H2('Where else is your organization available online?')}
+		<p>
+			If you don't have an account on all these platforms, it's totally fine to leave these blank.
+		</p>
+		<TextInput
+			superform={form}
+			type="text"
+			field="website"
+			label="Website"
+			description="The URL of your organization's website (leave blank if you don't have one)."
+		/>
+		<TextInput
+			superform={form}
+			type="text"
+			field="facebook"
+			label="Facebook"
+			description="The URL of your organization's Facebook page"
+		/>
+		<TextInput
+			superform={form}
+			type="text"
+			field="twitter"
+			label="Twitter/X"
+			description="Your organization's Twitter/X account"
+		/>
+		<TextInput
+			superform={form}
+			type="text"
+			field="instagram"
+			label="Instagram"
+			description="Your organization's Instagram account"
+		/>
+		<div>
+			<button
+				type="submit"
+				class="w-full mt-4 inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+			>
+				Continue
+			</button>
+		</div>
+		{#if dev}<SuperDebug data={$data} />{/if}
+	</form>
+{/if}
 
 {#snippet H1(text: string)}
 	<h1 class="text-3xl lg:text-4xl font-extrabold text-gray-800">{text}</h1>

--- a/src/routes/(utility)/onboarding/survey/CountrySelect.svelte
+++ b/src/routes/(utility)/onboarding/survey/CountrySelect.svelte
@@ -1,0 +1,103 @@
+<script lang="ts" generics="T extends Record<string, unknown>">
+	import { formFieldProxy, type SuperForm, type FormPathLeaves } from 'sveltekit-superforms';
+	import { cn } from '$lib/utils';
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	type Props = HTMLInputAttributes & {
+		superform: SuperForm<T>;
+		class?: string;
+		label?: string;
+		description?: string;
+		field: FormPathLeaves<T>;
+	};
+
+	let { superform, field, description, class: className, label, ...rest }: Props = $props();
+
+	let { value, errors, constraints } = formFieldProxy(superform, field);
+	($value as string | undefined) = undefined;
+	import { renderLocalizedCountryName, countryList } from '$lib/i18n/countries';
+
+	import * as m from '$lib/paraglide/messages';
+
+	import { getLocale } from '$lib/paraglide/runtime';
+	import { tick } from 'svelte';
+
+	import * as Popover from '$lib/comps/ui/popover';
+	import ChevronsUpDown from 'lucide-svelte/icons/chevrons-up-down';
+	import Check from 'lucide-svelte/icons/check';
+	import * as Command from '$lib/comps/ui/command';
+	import Button from '$lib/comps/ui/button/button.svelte';
+
+	const locale = getLocale();
+
+	const options = countryList.map((country) => ({
+		value: country.code,
+		label: `${country.flag} ${renderLocalizedCountryName(country.code, locale)}`
+	}));
+
+	let open = $state(false);
+	let triggerRef = $state<HTMLButtonElement>(null!);
+
+	const selectedValue = $derived(options.find((f) => f.value === $value)?.label);
+
+	// We want to refocus the trigger button when the user selects
+	// an item from the list so users can continue navigating the
+	// rest of the form with the keyboard.
+	function closeAndFocusTrigger() {
+		open = false;
+		tick().then(() => {
+			triggerRef.focus();
+		});
+	}
+</script>
+
+<div class={cn('flex flex-col gap-2', className)}>
+	{#if label}<label for="countryList"
+			><div class:text-red-700={$errors} class="ms-1 mb-1 text-sm font-medium text-gray-800">
+				{label}
+			</div></label
+		>{/if}
+	<Popover.Root bind:open>
+		<Popover.Trigger bind:ref={triggerRef}>
+			{#snippet child({ props })}
+				<Button
+					variant="outline"
+					class="w-full justify-between"
+					{...props}
+					role="combobox"
+					aria-expanded={open}
+				>
+					{selectedValue || 'Select a country...'}
+					<ChevronsUpDown class="opacity-50" />
+				</Button>
+			{/snippet}
+		</Popover.Trigger>
+		<Popover.Content class="w-full p-0">
+			<Command.Root>
+				<Command.Input placeholder="Select your country" id="countryList" />
+				<Command.List>
+					<Command.Empty>{m.tidy_cuddly_pelican_evoke()}</Command.Empty>
+					<Command.Group>
+						<Command.Item keywords={['Select a country']} value={undefined} disabled={true} />
+						{#each countryList as country}
+							<Command.Item
+								keywords={[renderLocalizedCountryName(country.code, locale)]}
+								value={country.code}
+								onSelect={() => {
+									($value as string) = country.code;
+									closeAndFocusTrigger();
+								}}
+							>
+								<Check class={cn($value !== country.code && 'text-transparent')} />
+								{`${country.flag} ${renderLocalizedCountryName(country.code, locale)}`}
+							</Command.Item>
+						{/each}
+					</Command.Group>
+				</Command.List>
+			</Command.Root>
+		</Popover.Content>
+	</Popover.Root>
+	{#if description}<div class="text-muted-foreground text-sm mt-1">
+			{description}
+		</div>{/if}
+</div>

--- a/src/routes/(utility)/onboarding/survey/TextInput.svelte
+++ b/src/routes/(utility)/onboarding/survey/TextInput.svelte
@@ -1,0 +1,53 @@
+<script lang="ts" generics="T extends Record<string, unknown>">
+	import { formFieldProxy, type SuperForm, type FormPathLeaves } from 'sveltekit-superforms';
+	import { cn } from '$lib/utils';
+	import type { HTMLInputAttributes } from 'svelte/elements';
+
+	type Props = HTMLInputAttributes & {
+		superform: SuperForm<T>;
+		class?: string;
+		label?: string;
+		type?: string;
+		description?: string;
+		field: FormPathLeaves<T>;
+	};
+
+	let {
+		superform,
+		type = 'text',
+		field,
+		description,
+		class: className,
+		label,
+		...rest
+	}: Props = $props();
+
+	const { value, errors, constraints } = formFieldProxy(superform, field);
+</script>
+
+<div>
+	<label>
+		{#if label}<div
+				class:text-red-700={$errors}
+				class="ms-1 mb-1 text-sm font-medium text-gray-800"
+			>
+				{label}
+			</div>{/if}
+		<input
+			name={field}
+			{type}
+			class={cn(
+				'block w-full rounded-lg border border-gray-300 bg-white p-2 text-sm font-normal text-gray-800  focus:border-gray-400 focus:ring-0',
+				className
+			)}
+			class:border-red-700={$errors}
+			class:focus:border-red-700={$errors}
+			aria-invalid={$errors ? 'true' : undefined}
+			bind:value={$value}
+			{...$constraints}
+			{...rest}
+		/>
+	</label>
+	{#if description}<div class="ms-1 mt-1 text-sm text-gray-500">{description}</div>{/if}
+	{#if $errors}<span class="mx-1 text-sm text-red-700">{$errors}</span>{/if}
+</div>

--- a/src/routes/(utility)/onboarding/survey/form.svelte.ts
+++ b/src/routes/(utility)/onboarding/survey/form.svelte.ts
@@ -1,0 +1,96 @@
+import {
+	shortStringNotEmpty,
+	v,
+	phoneNumber,
+	slug,
+	url,
+	email,
+	country,
+	mediumString
+} from '$lib/schema/valibot';
+import { superForm, defaults, type SuperValidated } from 'sveltekit-superforms';
+import { valibot } from 'sveltekit-superforms/adapters';
+
+export const validationSchema = v.object({
+	ownerName: shortStringNotEmpty,
+	whatsAppNumber: phoneNumber,
+	country: country,
+	instanceName: shortStringNotEmpty,
+	instanceSlug: slug,
+	instanceLogoUrl: url,
+
+	replyToEmail: email,
+
+	website: v.optional(v.nullable(url)),
+	facebook: v.optional(v.nullable(mediumString)),
+	instagram: v.optional(v.nullable(mediumString)),
+	twitter: v.optional(v.nullable(mediumString))
+});
+
+type Props<T extends Record<string, unknown>> = {
+	initialData?: T;
+	validateOnLoad?: boolean;
+	hideDebugger?: boolean;
+	onSubmit: (value: T, form: SuperValidated<T>) => Promise<void>;
+	class?: string;
+};
+
+export default function Form<T extends Record<string, unknown>>({
+	initialData,
+	validateOnLoad = true,
+	onSubmit
+}: Props<T>) {
+	const form = initialData
+		? //@ts-ignore There seems to be a type issue with defaulting to the generic initialData, but it works fine
+			superForm(defaults(initialData, valibot(validationSchema)), {
+				SPA: true,
+				dataType: 'json',
+				validators: valibot(validationSchema),
+				onUpdate({ form }) {
+					if (form.valid) {
+						// @ts-ignore Type error with generics? But also seems to work
+						onSubmit(form.data, form);
+					}
+				}
+			})
+		: superForm(defaults(valibot(validationSchema)), {
+				SPA: true,
+				dataType: 'json',
+				validators: valibot(validationSchema),
+				onUpdate({ form }) {
+					if (form.valid) {
+						// @ts-ignore Type error with generics? But also seems to work
+						onSubmit(form.data, form);
+					}
+				}
+			});
+	if (initialData && validateOnLoad) {
+		form.validateForm({ update: true });
+	}
+
+	function warnBeforeDiscard(isTainted: typeof form.isTainted, callback?: () => void) {
+		function callbackOrNavigateBack() {
+			if (callback) {
+				callback();
+			} else {
+				window.history.back();
+			}
+		}
+
+		if (isTainted()) {
+			if (confirm('You have unsaved changes. Are you sure you want to discard them?')) {
+				callbackOrNavigateBack();
+			}
+		} else {
+			callbackOrNavigateBack();
+		}
+	}
+
+	return {
+		warnBeforeDiscard,
+		form,
+		data: form.form,
+		errors: form.errors,
+		isTainted: form.isTainted
+	};
+}

--- a/src/routes/(utility)/onboarding/survey/form.svelte.ts
+++ b/src/routes/(utility)/onboarding/survey/form.svelte.ts
@@ -89,6 +89,8 @@ export default function Form<T extends Record<string, unknown>>({
 	return {
 		warnBeforeDiscard,
 		form,
+		capture: form.capture,
+		restore: form.restore,
 		data: form.form,
 		errors: form.errors,
 		isTainted: form.isTainted

--- a/src/routes/(utility)/onboarding/survey/onboard/+server.ts
+++ b/src/routes/(utility)/onboarding/survey/onboard/+server.ts
@@ -5,7 +5,12 @@ import { validationSchema } from '../form.svelte.js';
 import { parse } from '$lib/schema/valibot';
 import { type InstallOptions } from '$lib/server/utils/install/index.js';
 import * as jose from 'jose';
-import { JWT_SIGNING_SECRET, JWT_NAME, COOKIE_SESSION_NAME } from '$env/static/private';
+import {
+	JWT_SIGNING_SECRET,
+	JWT_NAME,
+	COOKIE_SESSION_NAME,
+	ONBOARDING_WEBHOOK_URL
+} from '$env/static/private';
 import { PUBLIC_HOST } from '$env/static/public';
 import type { RequestEvent } from './$types.js';
 import install from '$lib/server/utils/install/index.js';
@@ -58,6 +63,15 @@ export async function POST(event) {
 		httpOnly: true,
 		secure: dev ? false : true,
 		sameSite: 'strict'
+	});
+
+	// Send to Make
+	await fetch(`${ONBOARDING_WEBHOOK_URL}`, {
+		method: 'POST',
+		headers: {
+			'Content-Type': 'application/json'
+		},
+		body: JSON.stringify(parsedBody)
 	});
 
 	log.debug('authenticated.. now redirecting to the dashboard...');

--- a/src/routes/(utility)/onboarding/survey/onboard/+server.ts
+++ b/src/routes/(utility)/onboarding/survey/onboard/+server.ts
@@ -1,0 +1,11 @@
+import { json, error } from '$lib/server';
+import { validationSchema } from '../form.svelte.js';
+import { parse } from '$lib/schema/valibot';
+export async function POST(event) {
+	try {
+		const parsedBody = parse(validationSchema, await event.request.json());
+		return json({});
+	} catch (err) {
+		return error(500, 'API:/api/v1/events/[event_id]:GET', 'Unable to create account', err);
+	}
+}

--- a/src/routes/(utility)/onboarding/survey/onboard/+server.ts
+++ b/src/routes/(utility)/onboarding/survey/onboard/+server.ts
@@ -1,11 +1,89 @@
-import { json, error } from '$lib/server';
+import { error, pino } from '$lib/server';
+import { redirect } from '@sveltejs/kit';
+import { dev } from '$app/environment';
 import { validationSchema } from '../form.svelte.js';
 import { parse } from '$lib/schema/valibot';
+import { type InstallOptions } from '$lib/server/utils/install/index.js';
+import * as jose from 'jose';
+import { JWT_SIGNING_SECRET, JWT_NAME, COOKIE_SESSION_NAME } from '$env/static/private';
+import { PUBLIC_HOST } from '$env/static/public';
+import type { RequestEvent } from './$types.js';
+import install from '$lib/server/utils/install/index.js';
+import { signIn } from '$lib/server/api/core/admins.js';
+const log = pino(import.meta.url);
 export async function POST(event) {
-	try {
-		const parsedBody = parse(validationSchema, await event.request.json());
-		return json({});
-	} catch (err) {
-		return error(500, 'API:/api/v1/events/[event_id]:GET', 'Unable to create account', err);
+	//build the installation options
+	const parsedBody = parse(validationSchema, await event.request.json());
+	const signInDetails = await buildSignInObjectFromJwt(event);
+	const newInstanceOptions: InstallOptions = {
+		instanceName: parsedBody.instanceName,
+		instanceSlug: parsedBody.instanceSlug,
+		ownerEmail: signInDetails.email as string,
+		ownerProfilePictureUrl: signInDetails.profile_picture_url as string | undefined,
+		ownerName: parsedBody.ownerName,
+		logoUrl: parsedBody.instanceLogoUrl,
+		country: parsedBody.country,
+		language: 'en',
+		homePageUrl: parsedBody.website || undefined,
+		options: {
+			testData: false
+		}
+	};
+
+	await install(newInstanceOptions, event.locals.t, event.locals.queue);
+
+	log.debug('creating session...');
+	const { session } = await signIn({
+		body: {
+			email: signInDetails.email as string,
+			full_name: parsedBody.ownerName,
+			profile_picture_url: signInDetails.profile_picture_url as string | null,
+			google_token_type: signInDetails.google_token_type as string | null,
+			google_expires_in: null, // Not currently needed or used
+			google_refresh_token: null,
+			google_id: signInDetails.google_id as string | null,
+			google_access_token: signInDetails.google_access_token as string | null
+		}
+	});
+
+	log.debug(session, 'session created:');
+
+	// Set the session cookie to expire in 2 weeks
+	const today = new Date();
+	const expires = new Date(today.getTime() + 14 * 24 * 60 * 60 * 1000);
+
+	event.cookies.set(COOKIE_SESSION_NAME, session, {
+		path: '/',
+		expires: expires,
+		httpOnly: true,
+		secure: dev ? false : true,
+		sameSite: 'strict'
+	});
+
+	log.debug('authenticated.. now redirecting to the dashboard...');
+	return redirect(302, PUBLIC_HOST);
+}
+
+async function buildSignInObjectFromJwt(event: RequestEvent) {
+	//parse the JWT and reject if not valid
+	const jwt = event.cookies.get(JWT_NAME);
+	if (!jwt) {
+		return error(401, 'API:/api/v1/events/[event_id]:GET', 'JWT not found');
 	}
+	const validated = await jose.jwtVerify(jwt, new TextEncoder().encode(JWT_SIGNING_SECRET));
+
+	if (!validated) {
+		return error(401, 'API:/api/v1/events/[event_id]:GET', 'JWT not valid');
+	}
+
+	const signInDetails = {
+		full_name: validated.payload.roles,
+		google_token_type: validated.payload.typ,
+		google_expires_in: validated.payload.exp,
+		google_id: validated.payload.aud,
+		email: validated.payload.email,
+		profile_picture_url: validated.payload.sub_id,
+		google_access_token: validated.payload.sub
+	};
+	return signInDetails;
 }

--- a/src/routes/(utility)/onboarding/survey/upload/+server.ts
+++ b/src/routes/(utility)/onboarding/survey/upload/+server.ts
@@ -1,0 +1,22 @@
+/* body: JSON.stringify({
+  file_name: file.name
+}) */
+import { v } from '$lib/schema/valibot';
+import { json, error } from '$lib/server';
+import getSignedPutUrl from '$lib/server/utils/s3/put';
+import { PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME } from '$env/static/public';
+export async function POST(event) {
+	try {
+		const body = await event.request.json();
+		const parsed = v.parse(v.object({ file_name: v.string() }), body);
+		const url = await getSignedPutUrl(
+			PUBLIC_AWS_S3_SITE_UPLOADS_BUCKET_NAME,
+			parsed.file_name,
+			3600
+		);
+		return json({ put_url: url });
+	} catch (err) {
+		console.error(err);
+		return error(500, 'Error', 'Internal Server Error', err);
+	}
+}


### PR DESCRIPTION
This is a small PR to create a self-service onboarding flow. It creates a new form which begins with authentication (using a Google Account), which creates a JSON Web Token which is stored in cookies. 

Once the user has authenticated and the JWT is stored, the user is directed to a short onboarding survey which asks the core questions we need to create a new instance and admin record. 

Once the user submits that form, the information is used to create a new instance (leveraging the previously existing install script), and then the information stored in the JWT is used create a new session for the user as a newly created admin record. 

Finally, the user is redirected to `/`, the base dashboard route, where they are fully authenticated and logged into their new instance.  

## Some things to keep in mind
This is a first version of our onboarding flows. In the future, we will want to significantly refine and improve on these processes, so this should just be taken as a starting point. 

There are definitely some corners cut in order to get this out the door. Most notable, it's only in English. Not all the validations are perfect, and some information (eg: country and logo) doesn't seem to persist after errors have been generated. 

## Status

This isn't the best work I've ever done, and the error handling is particularly poor (sending back `?error=true` as a query param) -- but it should work and carry us through the next few weeks of onboarding.

## Screens
<img width="655" alt="image" src="https://github.com/user-attachments/assets/94c04c5e-bfc9-4568-bba8-502be9c9ce20" />

<img alt="image" src="https://github.com/user-attachments/assets/e5a24068-5c95-42b8-bd78-0556369d58fb" />
