### PR TITLE
Update svelte-french-toast to use svelte5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -75,7 +75,7 @@
 				"prettier-plugin-svelte": "^3.1.2",
 				"svelte": "^5.0.0-next.1",
 				"svelte-check": "^3.6.0",
-				"svelte-hot-french-toast": "^1.0.0",
+				"svelte-french-toast": "^2.0.0-alpha.0",
 				"svelte-sonner": "^0.3.28",
 				"sveltekit-flash-message": "^2.4.4",
 				"sveltekit-superforms": "^2.21.1",
@@ -13451,13 +13451,17 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/svelte-hot-french-toast": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/svelte-hot-french-toast/-/svelte-hot-french-toast-1.0.0.tgz",
-			"integrity": "sha512-SmJUwq7iHu9m0a794UBhCnp5YBQw0NV54j5z2oG+S/dtMMxbwC1s7bOGPpsPJrtZY7EED6jGV7BuulyorAaXWA==",
+		"node_modules/svelte-french-toast": {
+			"version": "2.0.0-alpha.0",
+			"resolved": "https://registry.npmjs.org/svelte-french-toast/-/svelte-french-toast-2.0.0-alpha.0.tgz",
+			"integrity": "sha512-81wcVaY9UZ/0JuzLEizMSoIXqNbX7yhfTZavBuw94T3cnT2HmJ9O+qXY/c91h9FkeMwboo0KHZVmzOEQVTXDFg==",
 			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"svelte-writable-derived": "^3.1.1"
+			},
 			"peerDependencies": {
-				"svelte": ">= 5"
+				"svelte": "^5.0.0"
 			}
 		},
 		"node_modules/svelte-preprocess": {
@@ -13565,6 +13569,19 @@
 			},
 			"peerDependencies": {
 				"svelte": "^5.0.0"
+			}
+		},
+		"node_modules/svelte-writable-derived": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/svelte-writable-derived/-/svelte-writable-derived-3.1.1.tgz",
+			"integrity": "sha512-w4LR6/bYZEuCs7SGr+M54oipk/UQKtiMadyOhW0PTwAtJ/Ai12QS77sLngEcfBx2q4H8ZBQucc9ktSA5sUGZWw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://ko-fi.com/pixievoltno1"
+			},
+			"peerDependencies": {
+				"svelte": "^3.2.1 || ^4.0.0-next.1 || ^5.0.0-next.94"
 			}
 		},
 		"node_modules/svelte/node_modules/is-reference": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
 		"prettier-plugin-svelte": "^3.1.2",
 		"svelte": "^5.0.0-next.1",
 		"svelte-check": "^3.6.0",
-		"svelte-hot-french-toast": "^1.0.0",
+		"svelte-french-toast": "^2.0.0-alpha.0",
 		"svelte-sonner": "^0.3.28",
 		"sveltekit-flash-message": "^2.4.4",
 		"sveltekit-superforms": "^2.21.1",

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -52,8 +52,7 @@
 	const { children } = $props();
 
 	import { getFlash } from 'sveltekit-flash-message';
-	//TODO: Replace with svelte-french-toast when it supports svelte 5
-	import toast, { Toaster } from 'svelte-hot-french-toast';
+	import toast, { Toaster } from 'svelte-french-toast';
 	const flash = getFlash(page);
 	flash.subscribe(($flash) => {
 		if (!$flash) return;


### PR DESCRIPTION
We were previously using a fork of this toasting library, because it didn't suppot svelte 5. But now they have released an alpha that has svelte 5 support (finally) so we can switch back.

This has the side effect of fixing issues with broken icons, so the toast messages should look good again.