### PR TITLE
Remove the last remaining references to on: events in .svelte files

### DIFF
--- a/src/lib/comps/ui/button/button.svelte
+++ b/src/lib/comps/ui/button/button.svelte
@@ -35,6 +35,7 @@
 		WithElementRef<HTMLAnchorAttributes> & {
 			variant?: ButtonVariant;
 			size?: ButtonSize;
+			onclick?: (event: MouseEvent) => void;
 		};
 </script>
 
@@ -49,6 +50,7 @@
 		href = undefined,
 		type = 'button',
 		children,
+		onclick,
 		...restProps
 	}: ButtonProps = $props();
 </script>
@@ -56,20 +58,20 @@
 {#if href}
 	<a
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{href}
 		{...restProps}
-		on:click
+		{onclick}
 	>
 		{@render children?.()}
 	</a>
 {:else}
 	<button
 		bind:this={ref}
-		class={cn(buttonVariants({ variant, size, className }))}
+		class={cn(buttonVariants({ variant, size }), className)}
 		{type}
 		{...restProps}
-		on:click
+		{onclick}
 	>
 		{@render children?.()}
 	</button>

--- a/src/routes/(app)/settings/admins/+page.svelte
+++ b/src/routes/(app)/settings/admins/+page.svelte
@@ -65,7 +65,7 @@
 				<Button
 					size="sm"
 					variant="destructive"
-					on:click={() => {
+					onclick={() => {
 						if (window.confirm(m.moving_acidic_crow_imagine())) {
 							deleteAdmin(admin.id);
 						}


### PR DESCRIPTION
The last remaining component with on: event directives that I could find (based on my searching) was the main button component (used very widely).

This PR changes it to use an optional onclick() prop.

Most places that this was being imported were working fine anyway, passing onclick which was being attached to either the <a> or <button> element as a {...restProps}.

Only one place was actually passing on:click and that has been updated.

The only remaining on: directive is a carousel component which has no file referneces and is not imported anywhere. I decided to keep it incase it would break anything.