### PR TITLE
Clear input after new mesage created

### DIFF
--- a/src/lib/comps/forms/whatsapp/messages/builder/CreateNewMessage.svelte
+++ b/src/lib/comps/forms/whatsapp/messages/builder/CreateNewMessage.svelte
@@ -28,6 +28,7 @@
 			class="btn btn-primary"
 			onclick={() => {
 				oncreate(message);
+				message.text.body = '';
 			}}
 		>
 			{m.tidy_watery_ape_lift()}


### PR DESCRIPTION
When a new message is created, the message text previously remained in the input. The user would have to manually delete it before creating a new message.

This change clears the input once the message is created.