### PR TITLE
Add a check to missing button actions before sending a message

### DIFF
--- a/src/lib/comps/forms/whatsapp/messages/builder/actions/components.ts
+++ b/src/lib/comps/forms/whatsapp/messages/builder/actions/components.ts
@@ -260,3 +260,32 @@ export function hasUnfilledPlaceholders(
 
 	return false;
 }
+import { type List } from '$lib/schema/communications/whatsapp/messages';
+
+export function hasUnattachedButtons(
+	template: any | null,
+	components: any[],
+	templateMessage: { type: string },
+	messages: List['items']
+) {
+	if (!template || templateMessage.type !== 'template') return false;
+	for (const message of messages) {
+		if (message.message.type === 'interactive' && message.message.interactive.type === 'button') {
+			const numButtons = message.message.interactive.action.buttons.length;
+			const numActions = Object.keys(message.actions).length;
+			if (numButtons > numActions) {
+				return true;
+			}
+		}
+		// now do the same for the template message
+		if (message.message.type === 'template' && message.message.template.components) {
+			const numButtons = message.message.template.components.filter(
+				(component) => component.type === 'button' && component.sub_type === 'quick_reply'
+			).length;
+			const numActions = Object.keys(message.actions).length;
+			if (numButtons > numActions) {
+				return true;
+			}
+		}
+	}
+}

--- a/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
+++ b/src/routes/(app)/communications/whatsapp/[thread_id]/+page.svelte
@@ -102,6 +102,13 @@
 			$flash = { type: 'error', message: 'Please fill in all placeholders before sending' };
 			return;
 		}
+		if (componentActions.hasUnattachedButtons(template, components, templateMessage, messages)) {
+			$flash = {
+				type: 'error',
+				message: 'Please make sure all buttons have actions before sending.'
+			};
+			return;
+		}
 		goto(`/communications/whatsapp/${data.thread.id}/sends`);
 	}
 </script>


### PR DESCRIPTION
When a user creates whatsapp message thread that includes interactive elements (ie: quick reply buttons), if the buttons don't have any actions attached they won't do anything when the user taps them.

As such, if the user tries to send a thread that has missing button actions, this is almost certainly an error.

This PR creates a function to check for that, and then throw up an error toast if there are missing actions in either interactive messages or in templates that contain buttons.