### PR TITLE
Update domain validation schema

### DIFF
--- a/src/lib/schema/valibot-strings.test.ts
+++ b/src/lib/schema/valibot-strings.test.ts
@@ -325,3 +325,42 @@ describe('uuid', () => {
 		expect(() => parse(uuid, '')).toThrow();
 	});
 });
+
+import { domainOrUrl } from '$lib/schema/valibot';
+describe('domainOrUrl', () => {
+	it('should parse a valid domain', () => {
+		expect(parse(domainOrUrl, 'example.com')).toBe('https://example.com/');
+		expect(parse(domainOrUrl, 'acts.eco')).toBe('https://acts.eco/');
+		expect(parse(domainOrUrl, 'good-domain.com')).toBe('https://good-domain.com/');
+		expect(parse(domainOrUrl, 'sub.domain.co.uk')).toBe('https://sub.domain.co.uk/');
+		expect(parse(domainOrUrl, 'sub.domain.co.uk/path')).toBe('https://sub.domain.co.uk/path');
+	});
+
+	it('should parse a valid URL, regardless of protocol', () => {
+		expect(parse(domainOrUrl, 'https://example.com')).toBe('https://example.com/');
+
+		expect(parse(domainOrUrl, 'http://sub.domain.co.uk/path')).toBe('http://sub.domain.co.uk/path');
+		expect(parse(domainOrUrl, 'ftp://sub.domain.co.uk/path')).toBe('ftp://sub.domain.co.uk/path');
+	});
+
+	it('should throw for an invalid URL', () => {
+		expect(() => parse(domainOrUrl, 'not a url')).toThrow();
+	});
+
+	it('should handle an extra slash in the protocol', () => {
+		expect(parse(domainOrUrl, 'http:///example.com')).toBe('http://example.com/');
+		expect(parse(domainOrUrl, 'https:///example.com')).toBe('https://example.com/');
+		expect(parse(domainOrUrl, 'https:///example.com/')).toBe('https://example.com/');
+	});
+
+	it('should throw if the URL is too long', () => {
+		const longUrl = 'https://example.com/' + 'a'.repeat(LONG_STRING_MAX_LENGTH);
+		expect(() => parse(domainOrUrl, longUrl)).toThrow();
+	});
+
+	it('should throw for non-string inputs', () => {
+		expect(() => parse(domainOrUrl, 123)).toThrow();
+		expect(() => parse(domainOrUrl, null)).toThrow();
+		expect(() => parse(domainOrUrl, {})).toThrow();
+	});
+});

--- a/src/lib/schema/valibot.ts
+++ b/src/lib/schema/valibot.ts
@@ -82,18 +82,6 @@ export const domainName = v.pipe(
 	v.regex(/^(?!-)([a-z0-9-]{1,63}(?<!-)\.)+[a-z]{2,6}$/iu, m.legal_antsy_alpaca_drip())
 );
 
-export const domainOrUrl = v.union([
-	domainName,
-	v.pipe(
-		v.string(),
-		v.maxLength(
-			LONG_STRING_MAX_LENGTH,
-			m.proud_house_thrush_shine({ maxLength: LONG_STRING_MAX_LENGTH })
-		),
-		v.url(m.whole_polite_loris_edit())
-	)
-]);
-
 export const email = v.pipe(v.string(), v.email(m.actual_early_anteater_endure()));
 export const url = v.pipe(
 	v.string(),
@@ -103,6 +91,21 @@ export const url = v.pipe(
 	),
 	v.url(m.whole_polite_loris_edit())
 );
+
+export const domainOrUrl = v.pipe(
+	longString,
+	v.transform((input) => {
+		try {
+			return new URL(input).href;
+		} catch (err) {
+			const fallback = new URL(`https://${input}`);
+			fallback.hostname = input;
+			return fallback.href;
+		}
+	}),
+	url
+);
+
 export const uuid = v.pipe(v.string(), v.uuid(m.suave_weird_meerkat_imagine()));
 
 export const integer = v.pipe(v.number(), v.integer(m.salty_mad_polecat_pray()));


### PR DESCRIPTION
This schema previously accepted domain namae looking strings (eg: example.com) or fully formed URLs (eg: https://example.com) and output them as-is.

This caused issues with the onboarding forms because the instance creation script expects the home page URL for an instance to be a fully formed URL.

This has now been updated to attempt to transform incoming strings into fully form URLs and output the URLs. It should only throw if the string cannot be coerced into a URL (ie: using new URL())

This commit also includes a number of test cases for this validation function, attempting to cover the kinds of URLs/domains that people might input into a form.